### PR TITLE
Some fixes and helpers.

### DIFF
--- a/stellar_base/asset.py
+++ b/stellar_base/asset.py
@@ -15,6 +15,15 @@ class Asset(object):
         self.code = code
         self.issuer = issuer
 
+    def to_dict(self):
+        rv = {'asset_code': self.code}
+        if not self.is_native():
+            rv['asset_issuer'] = self.issuer
+            rv['asset_type'] = len(self.code) > 4 and 'credit_alphanum12' or 'credit_alphanum4'
+        else:
+            rv['asset_type'] = 'native'
+        return rv
+
     @staticmethod
     def native():
         return Asset("XLM")

--- a/stellar_base/horizon.py
+++ b/stellar_base/horizon.py
@@ -40,6 +40,9 @@ class Horizon (object):
         p = requests.post(url, params=params, )  # timeout=20
         return json.loads(p.text)
 
+    def query(self, url, params=None, sse=False):
+        return query(self.horizon+url, params, sse)
+
     def accounts(self, params=None, sse=False):
         url = self.horizon + '/accounts/'
         return query(url, params, sse)

--- a/stellar_base/operation.py
+++ b/stellar_base/operation.py
@@ -127,29 +127,29 @@ class SetOptions(Operation):
         self.clear_flags = opts.get('clear_flags') or None
         self.set_flags = opts.get('set_flags') or None
         self.master_weight = opts.get('master_weight') or None
-        self.low_threshold = opts.get('lowThreshold') or None
-        self.med_threshold = opts.get('medThreshold') or None
+        self.low_threshold = opts.get('low_threshold') or None
+        self.med_threshold = opts.get('med_threshold') or None
         self.high_threshold = opts.get('high_threshold') or None
         self.home_domain = opts.get('home_domain') or None
         try:
-            self.singer_address = opts.get('signer').address
-            self.singer_weight = opts.get('signer').weight
+            self.signer_address = opts['signer_address']
+            self.signer_weight = opts['signer_weight']
         except KeyError:
-            self.singer_address = None
+            self.signer_address = None
 
     def to_xdr_object(self):
         if self.inflation_dest is not None:
             inflation_dest = account_xdr_object(self.inflation_dest)
         else:
             inflation_dest = None
-        if self.singer_address is not None:
-            singer = Xdr.types.Signer(account_xdr_object(self.singer_address), self.singer_weight)
+        if self.signer_address is not None:
+            signer = Xdr.types.Signer(account_xdr_object(self.signer_address), self.signer_weight)
         else:
-            singer = None
+            signer = None
 
         set_options_op = Xdr.types.SetOptionsOp(inflation_dest, self.clear_flags, self.set_flags,
                                                 self.master_weight, self.low_threshold, self.med_threshold,
-                                                self.high_threshold, self.home_domain, singer)
+                                                self.high_threshold, self.home_domain, signer)
         self.body.type = Xdr.const.SET_OPTIONS
         self.body.setOptionsOp = set_options_op
         return super(SetOptions, self).to_xdr_object()

--- a/stellar_base/utils.py
+++ b/stellar_base/utils.py
@@ -34,7 +34,7 @@ def account_xdr_object(account):
 def bytes_from_decode_data(s):
     """copy from base64._bytes_from_decode_data
     """
-    if isinstance(s, str):
+    if isinstance(s, (str, unicode)):
         try:
             return s.encode('ascii')
         except UnicodeEncodeError:


### PR DESCRIPTION
Fixing SetOptions, the signer address and weight was expecting an unexisting object type, now two opts dict keys. Also doing some consistency cosmetic changes.
Adding a helper method to run queries on Horizon using the configured base url.
Adding a helper method to retrieve an Asset info as a dict.
XDR packing account object would fail if address is of type unicode.