### PR TITLE
Fix best_rational_approximation

### DIFF
--- a/stellar_base/utils.py
+++ b/stellar_base/utils.py
@@ -12,6 +12,7 @@ try:
 except:
     import ed25519
 from stellar_base.stellarxdr import StellarXDR_pack as Xdr
+from fractions import Fraction
 import numpy
 from decimal import *
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+from nose.tools import raises
 from stellar_base import utils
 from stellar_base.stellarxdr import StellarXDR_pack as Xdr
 
@@ -15,3 +16,36 @@ class TestUtils():
     # def test_encode_check(self):
         # TODO
 
+    def test_best_rational_approximation(self):
+        assert {'n': 1, 'd': 10} == utils.best_rational_approximation("0.1")
+        assert {'n': 1, 'd': 100} == utils.best_rational_approximation("0.01")
+        assert {'n': 1, 'd': 1000} == utils.best_rational_approximation("0.001")
+        assert {'n': 54301793, 'd': 100000} == utils.best_rational_approximation("543.017930")
+        assert {'n': 31969983, 'd': 100000} == utils.best_rational_approximation("319.69983")
+        assert {'n': 93, 'd': 100} == utils.best_rational_approximation("0.93")
+        assert {'n': 1, 'd': 2} == utils.best_rational_approximation("0.5")
+        assert {'n': 173, 'd': 100} == utils.best_rational_approximation("1.730")
+        assert {'n': 5333399, 'd': 6250000} == utils.best_rational_approximation("0.85334384")
+        assert {'n': 11, 'd': 2} == utils.best_rational_approximation("5.5")
+        assert {'n': 272783, 'd': 100000} == utils.best_rational_approximation("2.72783")
+        assert {'n': 638082, 'd': 1} == utils.best_rational_approximation("638082.0")
+        assert {'n': 36731261, 'd': 12500000} == utils.best_rational_approximation("2.93850088")
+        assert {'n': 1451, 'd': 25} == utils.best_rational_approximation("58.04")
+        assert {'n': 8253, 'd': 200} == utils.best_rational_approximation("41.265")
+        assert {'n': 12869, 'd': 2500} == utils.best_rational_approximation("5.1476")
+        assert {'n': 4757, 'd': 50} == utils.best_rational_approximation("95.14")
+        assert {'n': 3729, 'd': 5000} == utils.best_rational_approximation("0.74580")
+        assert {'n': 4119, 'd': 1} == utils.best_rational_approximation("4119.0")
+        assert {'n': 1, 'd': 100000000} == utils.best_rational_approximation("0.00000001")
+        assert {'n': 1, 'd': 1000000000} == utils.best_rational_approximation("0.000000001")
+        assert {'n': 1, 'd': 500000000} == utils.best_rational_approximation("0.000000002")
+        assert {'n': 3, 'd': 1000000000} == utils.best_rational_approximation("0.000000003")
+        assert {'n': 2147483647, 'd': 1} == utils.best_rational_approximation("2147483647")
+
+    @raises(Exception)
+    def test_best_rational_approximation_not_found_denominator(self):
+        utils.best_rational_approximation("0.0000000003")
+
+    @raises(Exception)
+    def test_best_rational_approximation_not_found_numerator(self):
+        utils.best_rational_approximation("2147483648")


### PR DESCRIPTION
There were some problems with previous implementation of `best_rational_approximation`:
```python
def best_rational_approximation(x):
   p = Fraction(x).limit_denominator(10**8)
   return {'n': p.numerator,'d': p.denominator}
```
1. The value passed to `limit_denominator` was incorrect. The max value `Price.n` and `Price.d` can hold is `2147483647` ([check XDR](https://github.com/stellar/stellar-core/blob/master/src/xdr/Stellar-ledger-entries.x#L45-L49)).
2. The previous implementation was not limiting `numerator` value at all so it could cause passing some unexpected price to the ledger.

I ported the continued fraction algorithm we use in ruby, js and java libraries and added tests.

PS. The last time I wrote python code was a few years ago so let me know if I made any stupid error :smile:. 