### PR TITLE
moved asset type to be an attribute of Asset object

### DIFF
--- a/stellar_base/asset.py
+++ b/stellar_base/asset.py
@@ -15,15 +15,19 @@ class Asset(object):
 
         self.code = code
         self.issuer = issuer
+        self.type = self.guessAssetType()
 
     def __eq__(self, other):
         return self.xdr() == other.xdr()
+
+    def guessAssetType(self):
+        return len(self.code) > 4 and 'credit_alphanum12' or 'credit_alphanum4'
 
     def to_dict(self):
         rv = {'asset_code': self.code}
         if not self.is_native():
             rv['asset_issuer'] = self.issuer
-            rv['asset_type'] = len(self.code) > 4 and 'credit_alphanum12' or 'credit_alphanum4'
+            rv['asset_type'] = self.type
         else:
             rv['asset_type'] = 'native'
         return rv


### PR DESCRIPTION
When making an order book request, the Asset type is a required parameter for both selling and buying Asset, so it would be easier to wrap the horizon order book parameters if the Asset object provides the type as a public attribute.  