### PR TITLE
Convert path assets to XDR objects

### DIFF
--- a/stellar_base/operation.py
+++ b/stellar_base/operation.py
@@ -323,10 +323,11 @@ class PathPayment(Operation):
         destination = account_xdr_object(self.destination)
         send_asset = self.send_asset.to_xdr_object()
         dest_asset = self.dest_asset.to_xdr_object()
+        path = [asset.to_xdr_object() for asset in self.path]
 
         path_payment = Xdr.types.PathPaymentOp(
             send_asset, Operation.to_xdr_amount(self.send_max), destination,
-            dest_asset, Operation.to_xdr_amount(self.dest_amount), self.path)
+            dest_asset, Operation.to_xdr_amount(self.dest_amount), path)
         self.body.type = Xdr.const.PATH_PAYMENT
         self.body.pathPaymentOp = path_payment
         return super(PathPayment, self).to_xdr_object()


### PR DESCRIPTION
Path payments were not working at all, always throwing an exception

```
  File "/home/jimbob/.virtualenvs/zed/lib/python3.5/site-packages/stellar_base/builder.py", line 307, in sign
    self.te.sign(key_pair)
  File "/home/jimbob/.virtualenvs/zed/lib/python3.5/site-packages/stellar_base/transaction_envelope.py", line 22, in sign
    tx_hash = self.hash_meta()
  File "/home/jimbob/.virtualenvs/zed/lib/python3.5/site-packages/stellar_base/transaction_envelope.py", line 41, in hash_meta
    return xdr_hash(self.signature_base())
  File "/home/jimbob/.virtualenvs/zed/lib/python3.5/site-packages/stellar_base/transaction_envelope.py", line 50, in signature_base
    tx.pack_Transaction(self.tx.to_xdr_object())
  File "/home/jimbob/.virtualenvs/zed/lib/python3.5/site-packages/stellar_base/stellarxdr/StellarXDR_pack.py", line 770, in pack_Transaction
    self.pack_array(data.operations, self.pack_Operation)
  File "/usr/lib/python3.5/xdrlib.py", line 128, in pack_array
    self.pack_farray(n, list, pack_item)
  File "/usr/lib/python3.5/xdrlib.py", line 123, in pack_farray
    pack_item(item)
  File "/home/jimbob/.virtualenvs/zed/lib/python3.5/site-packages/stellar_base/stellarxdr/StellarXDR_pack.py", line 665, in pack_Operation
    self.pack_PathPaymentOp(data.body.pathPaymentOp)
  File "/home/jimbob/.virtualenvs/zed/lib/python3.5/site-packages/stellar_base/stellarxdr/StellarXDR_pack.py", line 508, in pack_PathPaymentOp
    self.pack_array(data.path, self.pack_Asset)
  File "/usr/lib/python3.5/xdrlib.py", line 128, in pack_array
    self.pack_farray(n, list, pack_item)
  File "/usr/lib/python3.5/xdrlib.py", line 123, in pack_farray
    pack_item(item)
  File "/home/jimbob/.virtualenvs/zed/lib/python3.5/site-packages/stellar_base/stellarxdr/StellarXDR_pack.py", line 189, in pack_Asset
    self.pack_AssetType(data.type)
  File "/home/jimbob/.virtualenvs/zed/lib/python3.5/site-packages/stellar_base/stellarxdr/StellarXDR_pack.py", line 181, in pack_AssetType
    raise XDRError('value=%s not in enum AssetType' % data)
xdrlib.Error: value=credit_alphanum4 not in enum AssetType
```

This resolves that issue by encoding the path assets into xdr objects like the sender and destination assets already are.