### PR TITLE
Fix ManageData defect when data_val is None(remove data)

### DIFF
--- a/stellar_base/operation.py
+++ b/stellar_base/operation.py
@@ -967,7 +967,7 @@ class ManageData(Operation):
 
         valid_data_name_len = len(self.data_name) <= 64
         valid_data_val_len = (
-            self.data_value is not None and len(self.data_value) <= 64)
+            self.data_value is None or len(self.data_value) <= 64)
 
         if not valid_data_name_len or not valid_data_val_len:
             raise XdrLengthError(


### PR DESCRIPTION
`builder.append_manage_data_op` not working when removing the data value.