### PR TITLE
refactor operation construction

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,7 +15,6 @@ plugins:
 
 exclude_patterns:
   - "docs/"
-  - "tests/"
   - "stellar_base/xdr/"
   - "stellar_base/wordlist/"
   - "stellar_base/stellarxdr/"

--- a/stellar_base/operation.py
+++ b/stellar_base/operation.py
@@ -99,7 +99,7 @@ class Operation(object):
         """
         if not isinstance(value, str):
             raise TypeError("value of type '{}' is not a string"
-                            ".".format(type(value)))
+                            ".".format(type(value).__name__))
 
         # throw exception if value * ONE has decimal places (it can't be
         # represented as int64)

--- a/stellar_base/stellarxdr/StellarXDR_pack.py
+++ b/stellar_base/stellarxdr/StellarXDR_pack.py
@@ -4,8 +4,10 @@ from . import StellarXDR_type as types
 import xdrlib
 from xdrlib import Error as XDRError
 
+
 class nullclass(object):
     pass
+
 
 class StellarXDRPacker(xdrlib.Packer):
     def __init__(self, check_enum=True, check_array=True):

--- a/stellar_base/utils.py
+++ b/stellar_base/utils.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 from __future__ import print_function
-
+import sys
 import base64
 import binascii
 from decimal import Decimal, ROUND_FLOOR
@@ -20,9 +20,7 @@ from .stellarxdr import Xdr
 from .exceptions import DecodeError, ConfigurationError, MnemonicError
 
 # Compatibility for Python 3.x that don't have unicode type
-try:
-    type(unicode)
-except NameError:
+if sys.version_info.major == 3:
     unicode = str
 
 bytes_types = (bytes, bytearray)  # Types acceptable as binary data

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -41,7 +41,9 @@ class TestOp:
 
     def test_from_xdr_object_raise(self):
         operation = mock.MagicMock(type=2561)
-        pytest.raises(NotImplementedError, Operation.from_xdr_object, operation)
+        pytest.raises(
+            NotImplementedError, Operation.from_xdr_object, operation
+        )
 
     def test_createAccount_min(self):
         op = CreateAccount({
@@ -223,8 +225,11 @@ class TestOp:
         assert op_x.data_name == '1KFHE7w8BhaENAswwryaoccDb6qcT6DbYY'
         assert op_x.data_value == self.source
 
-    def test_manage_data_toolong(self):
-        with pytest.raises(XdrLengthError, match='Data or value should be <= 64 bytes \(ascii encoded\).'):
+    def test_manage_data_too_long(self):
+        with pytest.raises(
+                XdrLengthError,
+                match='Data or value should be <= 64 bytes \(ascii encoded\).'
+        ):
             ManageData({
                 'data_name': '1KFHE7w8BhaENAswwryaoccDb6qcT6DbYY',
                 'data_value': '1234567890' * 7

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1,5 +1,5 @@
 # coding:utf-8
-
+import mock
 import pytest
 
 from stellar_base.operation import *
@@ -22,7 +22,8 @@ class TestXdrAmount:
             Operation.to_xdr_amount("test")
 
     def test_to_xdr_amount_not_string(self):
-        with pytest.raises(Exception, match='value must be a string'):
+        with pytest.raises(
+                TypeError, match="value of type 'float' is not a string"):
             Operation.to_xdr_amount(0.1234)
 
     def test_from_xdr_amount(self):
@@ -37,6 +38,10 @@ class TestOp:
     seed = 'SAHPFH5CXKRMFDXEIHO6QATHJCX6PREBLCSFKYXTTCDDV6FJ3FXX4POT'
     dest = 'GCW24FUIFPC2767SOU4JI3JEAXIHYJFIJLH7GBZ2AVCBVP32SJAI53F5'
     amount = "1"
+
+    def test_from_xdr_object_raise(self):
+        operation = mock.MagicMock(type=2561)
+        pytest.raises(NotImplementedError, Operation.from_xdr_object, operation)
 
     def test_createAccount_min(self):
         op = CreateAccount({

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-
+import pytest
 from stellar_base.memo import *
 from stellar_base.operation import *
 from stellar_base.transaction import Transaction
@@ -11,6 +11,17 @@ class TestTx:
     source = 'GDJVFDG5OCW5PYWHB64MGTHGFF57DRRJEDUEFDEL2SLNIOONHYJWHA3Z'
     seed = 'SAHPFH5CXKRMFDXEIHO6QATHJCX6PREBLCSFKYXTTCDDV6FJ3FXX4POT'
     dest = 'GCW24FUIFPC2767SOU4JI3JEAXIHYJFIJLH7GBZ2AVCBVP32SJAI53F5'
+
+    def test_init_raise_redundant_argument(self):
+        pytest.raises(
+            ValueError, Transaction, self.source,
+            opts={"dummy": [], "sequence": 1}
+        )
+
+    def test_init_raise_account_code_wrong(self):
+        pytest.raises(
+            DecodeError, Transaction, self.source + "1", opts={"sequence": 1}
+        )
 
     def do(self, network, opts):
         tx = Transaction(self.source, opts)

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -20,7 +20,7 @@ class TestTx:
 
     def test_init_raise_account_code_wrong(self):
         pytest.raises(
-            DecodeError, Transaction, self.source + "1", opts={"sequence": 1}
+            Exception, Transaction, self.source + "1", opts={"sequence": 1}
         )
 
     def do(self, network, opts):


### PR DESCRIPTION
Hi again,

This PR mainly
- Refactored the operation construction from if ... else to subclass scan
- Removed some redundant assert (no need to assert isinstance dict if later a .get is called)
- Fixed some general error handling

By the way, it's really a good idea to change some dictionary argument like `opts` in `Transaction.__init__` to keyword arguments. Just it will introduce some breaking change, but it will be more user-friendly, what do you think ?