### PR TITLE
Optimize the processing of hex and bytes hash

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,6 +33,6 @@ And you can always clone `the repository <https://github.com/StellarCN/py-stella
 
 .. code-block:: bash
 
-    git clone git@github.com:StellarCN/py-stellar-base.git;
-    cd stellar_base;
+    git clone https://github.com/StellarCN/py-stellar-base.git
+    cd py-stellar-base
     pip install .

--- a/examples/issue_asset.py
+++ b/examples/issue_asset.py
@@ -26,7 +26,7 @@ print(resp)
 builder = Builder(
     issuing_secret, network='TESTNET').append_payment_op(
         destination=receiving_public,
-        amount=1000,
+        amount='1000',
         asset_code=my_asset.code,
         asset_issuer=my_asset.issuer)
 builder.sign()

--- a/examples/payment.py
+++ b/examples/payment.py
@@ -3,7 +3,7 @@ from stellar_base.builder import Builder
 alice_secret = 'SCB6JIZUC3RDHLRGFRTISOUYATKEE63EP7MCHNZNXQMQGZSLZ5CNRTKK'
 bob_address = 'GA7YNBW5CBTJZ3ZZOWX3ZNBKD6OE7A7IHUQVWMY62W2ZBG2SGZVOOPVH'
 
-builder = Builder(secret=alice_secret)
+builder = Builder(secret=alice_secret, horizon='https://horizon.stellar.org', network='TESTNET')
 builder.add_text_memo("Hello, Stellar!").append_payment_op(
     destination=bob_address, amount='12.25', asset_code='XLM')
 builder.sign()

--- a/examples/payment.py
+++ b/examples/payment.py
@@ -3,7 +3,7 @@ from stellar_base.builder import Builder
 alice_secret = 'SCB6JIZUC3RDHLRGFRTISOUYATKEE63EP7MCHNZNXQMQGZSLZ5CNRTKK'
 bob_address = 'GA7YNBW5CBTJZ3ZZOWX3ZNBKD6OE7A7IHUQVWMY62W2ZBG2SGZVOOPVH'
 
-builder = Builder(secret=alice_secret, horizon='https://horizon.stellar.org', network='TESTNET')
+builder = Builder(secret=alice_secret, horizon='https://horizon.stellar.org', network='PUBLIC')
 builder.add_text_memo("Hello, Stellar!").append_payment_op(
     destination=bob_address, amount='12.25', asset_code='XLM')
 builder.sign()

--- a/stellar_base/builder.py
+++ b/stellar_base/builder.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import binascii
 
 from .asset import Asset
 from .horizon import HORIZON_LIVE, HORIZON_TEST
@@ -667,6 +668,14 @@ class Builder(object):
         tx_xdr = self.gen_tx().xdr()
         self.sequence = sequence
         return tx_xdr
+
+    def hash(self):
+        """Return a hash for this transaction.
+
+        :return A hash for this transaction.
+        :rtype str
+        """
+        return binascii.hexlify(self.gen_te().hash_meta()).decode()
 
     def import_from_xdr(self, xdr):
         """Create a :class:`TransactionEnvelope

--- a/stellar_base/builder.py
+++ b/stellar_base/builder.py
@@ -276,8 +276,9 @@ class Builder(object):
         :param str home_domain: Sets the home domain of an account. See
             Stellar's documentation on `Federation
             <https://www.stellar.org/developers/guides/concepts/federation.html>`_.
-        :param str signer_address: The address of the new signer to add to the
+        :param signer_address: The address of the new signer to add to the
             source account.
+        :type signer_address: str, bytes
         :param str signer_type: The type of signer to add to the account. Must
             be in ('ed25519PublicKey', 'hashX', 'preAuthTx'). See Stellar's
             documentation for `Multi-Sign
@@ -303,7 +304,8 @@ class Builder(object):
         <stellar_base.operation.SetOptions` operation. This is a helper
         function for :meth:`append_set_options_op`.
 
-        :param str hashx: The address of the new hashX signer.
+        :param hashx: The address of the new hashX signer.
+        :type hashx: str, bytes
         :param int signer_weight: The weight of the new signer.
         :param str source: The source account that is adding a signer to its
             list of signers.
@@ -326,7 +328,8 @@ class Builder(object):
         <stellar_base.operation.SetOptions` operation. This is a helper
         function for :meth:`append_set_options_op`.
 
-        :param str pre_auth_tx: The address of the new preAuthTx signer - obtained by calling `hash_meta` on the TransactionEnvelope.
+        :param pre_auth_tx: The address of the new preAuthTx signer - obtained by calling `hash_meta` on the TransactionEnvelope.
+        :type pre_auth_tx: str, bytes
         :param int signer_weight: The weight of the new signer.
         :param str source: The source account that is adding a signer to its
             list of signers.
@@ -516,7 +519,8 @@ class Builder(object):
         """Set the memo for the transaction to a new :class:`HashMemo
         <stellar_base.memo.HashMemo>`.
 
-        :param bytes memo_hash: A 32 byte hash to use as the memo.
+        :param memo_hash: A 32 byte hash or hex encoded string to use as the memo.
+        :type memo_hash: bytes, str
         :return: This builder instance.
 
         """
@@ -527,8 +531,9 @@ class Builder(object):
         """Set the memo for the transaction to a new :class:`RetHashMemo
         <stellar_base.memo.RetHashMemo>`.
 
-        :param bytes memo_return: A 32 byte hash intended to be interpreted as
+        :param bytes memo_return: A 32 byte hash or hex encoded string intended to be interpreted as
             the hash of the transaction the sender is refunding.
+        :type memo_return: bytes, str
         :return: This builder instance.
 
         """
@@ -720,8 +725,9 @@ class Builder(object):
     def sign_preimage(self, preimage):
         """Sign the generated transaction envelope using a Hash(x) signature.
 
-        :param str preimage: The value to be hashed and used as a signer on the
+        :param preimage: The value to be hashed and used as a signer on the
             transaction envelope.
+        :type preimage: str, bytes
 
         """
         if self.te is None:

--- a/stellar_base/memo.py
+++ b/stellar_base/memo.py
@@ -4,6 +4,7 @@ import six
 import abc
 import base64
 
+from stellar_base.utils import convert_hex_to_bytes
 from .stellarxdr import Xdr
 from .exceptions import XdrLengthError
 
@@ -102,16 +103,12 @@ class IdMemo(Memo):
 class HashMemo(Memo):
     """The :class:`HashMemo` which represents MEMO_HASH in a transaction.
 
-    :param bytes memo_hash: A 32 byte hash.
-
+    :param memo_hash: A 32 byte hash or hex encoded string.
+    :type memo_hash: bytes, str
     """
 
     def __init__(self, memo_hash):
-        if len(memo_hash) != 32:
-            raise XdrLengthError("Expects a 32 byte mhash value. "
-                                 "Got {:d} bytes instead".format(
-                                     len(memo_hash)))
-        self.memo_hash = memo_hash
+        self.memo_hash = convert_hex_to_bytes(memo_hash)
 
     def to_xdr_object(self):
         """Creates an XDR Memo object for a transaction with MEMO_HASH."""
@@ -125,17 +122,14 @@ class RetHashMemo(Memo):
     a 32 byte hash intended to be interpreted as the hash of the transaction
     the sender is refunding.
 
-    :param bytes memo_return: A 32 byte hash intended to be interpreted as the
+    :param memo_return: A 32 byte hash or hex encoded string intended to be interpreted as the
         hash of the transaction the sender is refunding.
+    :type memo_return: bytes, str
 
     """
 
     def __init__(self, memo_return):
-        if len(memo_return) != 32:
-            raise XdrLengthError("Expects a 32 byte hash value. "
-                                 "Got {:d} bytes instead".format(
-                                     len(memo_return)))
-        self.memo_return = memo_return
+        self.memo_return = convert_hex_to_bytes(memo_return)
 
     def to_xdr_object(self):
         """Creates an XDR Memo object for a transaction with MEMO_RETURN."""

--- a/stellar_base/operation.py
+++ b/stellar_base/operation.py
@@ -7,7 +7,7 @@ from .asset import Asset
 from .stellarxdr import Xdr
 from .utils import (account_xdr_object, best_rational_approximation as best_r,
                     division, encode_check, signer_key_xdr_object,
-                    is_valid_address)
+                    is_valid_address, convert_hex_to_bytes)
 from .exceptions import XdrLengthError
 
 ONE = Decimal(10**7)
@@ -614,19 +614,16 @@ class SetOptions(Operation):
             self.signer_type = 'ed25519PublicKey'
 
         signer_is_invalid_type = (
-            self.signer_type is not None and
-            self.signer_type not in ('ed25519PublicKey', 'hashX', 'preAuthTx'))
+                self.signer_type is not None and
+                self.signer_type not in ('ed25519PublicKey', 'hashX', 'preAuthTx'))
 
         if signer_is_invalid_type:
             raise ValueError('Invalid signer type, sign_type should '
                              'be ed25519PublicKey, hashX or preAuthTx')
 
-        signer_addr_has_valid_len = (self.signer_address is not None
-                                     and len(self.signer_address) == 32)
+        if self.signer_type in ('hashX', 'preAuthTx'):
+            self.signer_address = convert_hex_to_bytes(self.signer_address)
 
-        if (self.signer_type in ('hashX', 'preAuthTx')
-                and not signer_addr_has_valid_len):
-            raise ValueError('hashX or preAuthTx Signer must be 32 bytes')
 
     def to_xdr_object(self):
         """Creates an XDR Operation object that represents this

--- a/stellar_base/transaction_envelope.py
+++ b/stellar_base/transaction_envelope.py
@@ -5,7 +5,7 @@ from .keypair import Keypair
 from .network import Network, NETWORKS
 from .stellarxdr import Xdr
 from .transaction import Transaction
-from .utils import hashX_sign_decorated, xdr_hash
+from .utils import hashX_sign_decorated, xdr_hash, convert_hex_to_bytes
 from .exceptions import SignatureExistError, PreimageLengthError
 
 
@@ -69,12 +69,14 @@ class TransactionEnvelope(object):
         <https://www.stellar.org/developers/guides/concepts/multi-sig.html>`_
         for more details on Hash(x) signatures.
 
-        :param str preimage: The "x" value to be hashed and used as a
+        :param preimage: 32 byte hash or hex encoded string, the "x" value to be hashed and used as a
             signature.
+        :type preimage: str, bytes
 
         """
         if len(preimage) > 64:
             raise PreimageLengthError('preimage must <= 64 bytes')
+        preimage = convert_hex_to_bytes(preimage)
         sig = hashX_sign_decorated(preimage)
         sig_dict = [signature.__dict__ for signature in self.signatures]
         if sig.__dict__ in sig_dict:

--- a/stellar_base/utils.py
+++ b/stellar_base/utils.py
@@ -61,7 +61,7 @@ def signer_key_xdr_object(signer_type, signer):
 
 
 def hashX_sign_decorated(preimage):
-    preimage = preimage.encode('utf-8')
+    # preimage -> bytes_here
     hash_preimage = hashlib.sha256(preimage).digest()
     hint = hash_preimage[-4:]
     return Xdr.types.DecoratedSignature(hint, preimage)
@@ -256,3 +256,16 @@ def is_valid_secret_key(key):
         return decode_check('seed', key)
     except Exception:
         return False
+
+
+def convert_hex_to_bytes(value):
+    # Not perfect but works on Python2 and Python3
+    if len is None:
+        raise ValueError("Value should be 32 byte hash or hex encoded string, but got None")
+    length = len(value)
+    if length == 32:
+        return value
+    elif length == 64:
+        return binascii.unhexlify(value)
+    else:
+        raise ValueError("Value should be 32 byte hash or hex encoded string, but got {}".format(value))

--- a/tests/test_memo.py
+++ b/tests/test_memo.py
@@ -51,10 +51,10 @@ class TestMemo:
         self.__asset_memo('ret_hash', memo_hash, ret_hash_memo)
 
     def test_hash_memo_and_ret_hash_memo_toolong(self):
-        memo_hash = binascii.hexlify(os.urandom(32))
-        with pytest.raises(XdrLengthError):
+        memo_hash = binascii.hexlify(os.urandom(32)).decode() + ' '
+        with pytest.raises(ValueError):
             HashMemo(memo_hash)
-        with pytest.raises(XdrLengthError):
+        with pytest.raises(ValueError):
             RetHashMemo(memo_hash)
 
     def test_memo_xdr(self):


### PR DESCRIPTION
Hash Memo, Return Hash Memo, PreAuthTx, hashX Signer accept 32 bytes hash or hex encoded string now.

Thanks to Areghan.