### PR TITLE
SEP-10: added support for 'client_domain' ManageData operations in challenges (client attribution)

### DIFF
--- a/stellar_sdk/sep/stellar_web_authentication.py
+++ b/stellar_sdk/sep/stellar_web_authentication.py
@@ -82,6 +82,8 @@ def build_challenge_transaction(
         source=server_account.account_id,
     )
     if client_domain:
+        if not client_signing_key:
+            raise ValueError("client_signing_key is required if client_domain is provided.")
         transaction_builder.append_manage_data_op(
             data_name="client_domain",
             data_value=client_domain,
@@ -243,7 +245,6 @@ def read_challenge_transaction(
         )
 
     # TODO: I don't think this is a good idea.
-    # What if we used the Java SDK's approach and had a ChallengeTransaction class?
     return transaction_envelope, client_account, matched_home_domain
 
 

--- a/stellar_sdk/sep/stellar_web_authentication.py
+++ b/stellar_sdk/sep/stellar_web_authentication.py
@@ -507,7 +507,7 @@ def verify_challenge_transaction(
         validation fails, the exception will be thrown.
     """
 
-    tx_envelope, client_account_id, _ = read_challenge_transaction(
+    _, client_account_id, _ = read_challenge_transaction(
         challenge_transaction,
         server_account_id,
         home_domains,


### PR DESCRIPTION
Adds bare-bones SDK support for SEP-10 challenges including the experimental 'client_domain' Manage Data operation used for client attribution.

SEP-10 PR: stellar/stellar-protocol#760

The changes made here do not implement all verifications described in the protocol change linked above. The specific changes made are:
- `read_challenge_transaction()` accepts Manage Data operations with source accounts not equal to `server_account_id` if the data name of operation is `client_domain`.
    - This differs from the current behavior, in which the function would raise an error if an additional operation did not have it's source account set to `server_account_id`
- `verify_challenge_transaction_signers()` verifies that the source account of the `client_domain` Manage Data operation signed the challenge transaction, if such operation is present

I welcome suggestions to this approach. Tests will be added once the functional changes made have been agreed upon.

I plan to use this functionality in a beta release of Polaris so key stakeholders can test the changes proposed by the PR.