### PR TITLE
fix: make `AiohttpClient` compatible with Python 3.6 and 3.7

### DIFF
--- a/stellar_sdk/client/aiohttp_client.py
+++ b/stellar_sdk/client/aiohttp_client.py
@@ -211,7 +211,7 @@ class AiohttpClient(BaseAsyncClient):
                 raise StreamClientError(
                     query_params["cursor"], "Failed to get stream message."
                 ) from e
-            except asyncio.exceptions.TimeoutError:
+            except asyncio.TimeoutError:
                 logger.warning(
                     f"We have encountered an timeout error and we will try to reconnect, cursor = {query_params.get('cursor')}"
                 )


### PR DESCRIPTION
`asyncio.exceptions.TimeoutError` available in Python 3.8 and above

#448 