### PR TITLE
fix: fix the problem that `not_predicate` cannot be parsed normally.

### DIFF
--- a/stellar_sdk/xdr/claim_predicate.py
+++ b/stellar_sdk/xdr/claim_predicate.py
@@ -115,7 +115,8 @@ class ClaimPredicate:
                 or_predicates.append(ClaimPredicate.unpack(unpacker))
             return cls(type, or_predicates=or_predicates)
         if type == ClaimPredicateType.CLAIM_PREDICATE_NOT:
-            not_predicate = ClaimPredicate.unpack(unpacker)
+            # not_predicate is optional.
+            not_predicate = ClaimPredicate.unpack(unpacker) if unpacker.unpack_uint() else None
             if not_predicate is None:
                 raise ValueError("not_predicate should not be None.")
             return cls(type, not_predicate=not_predicate)

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -44,7 +44,7 @@ from stellar_sdk.operation.utils import (
 from stellar_sdk.signer import Signer
 from stellar_sdk.signer_key import SignerKey
 from stellar_sdk.utils import sha256
-
+from stellar_sdk.xdr.claim_predicate import ClaimPredicate as XdrClaimPredicate
 
 class TestBaseOperation:
     @pytest.mark.parametrize(
@@ -1355,26 +1355,30 @@ class TestClaimPredicate:
         xdr = "AAAAAA=="
         predicate = ClaimPredicate.predicate_unconditional()
         assert xdr == self.to_xdr(predicate)
-        assert predicate == ClaimPredicate.from_xdr_object(predicate.to_xdr_object())
+        xdr_object = XdrClaimPredicate.from_xdr(xdr)
+        assert predicate == ClaimPredicate.from_xdr_object(xdr_object)
 
     def test_predicate_before_relative_time(self):
         xdr = "AAAABQAAAAAAAAPo"
         predicate = ClaimPredicate.predicate_before_relative_time(1000)
         assert xdr == self.to_xdr(predicate)
-        assert predicate == ClaimPredicate.from_xdr_object(predicate.to_xdr_object())
+        xdr_object = XdrClaimPredicate.from_xdr(xdr)
+        assert predicate == ClaimPredicate.from_xdr_object(xdr_object)
 
     def test_predicate_before_absolute_time(self):
         xdr = "AAAABAAAAABfc0qi"
         predicate = ClaimPredicate.predicate_before_absolute_time(1601391266)
         assert xdr == self.to_xdr(predicate)
-        assert predicate == ClaimPredicate.from_xdr_object(predicate.to_xdr_object())
+        xdr_object = XdrClaimPredicate.from_xdr(xdr)
+        assert predicate == ClaimPredicate.from_xdr_object(xdr_object)
 
     def test_predicate_not(self):
         xdr = "AAAAAwAAAAEAAAAEAAAAAF9zSqI="
         predicate_abs = ClaimPredicate.predicate_before_absolute_time(1601391266)
         predicate = ClaimPredicate.predicate_not(predicate_abs)
         assert xdr == self.to_xdr(predicate)
-        assert predicate == ClaimPredicate.from_xdr_object(predicate.to_xdr_object())
+        xdr_object = XdrClaimPredicate.from_xdr(xdr)
+        assert predicate == ClaimPredicate.from_xdr_object(xdr_object)
 
     def test_predicate_and_1(self):
         xdr = "AAAAAQAAAAIAAAAEAAAAAF9zSqIAAAAFAAAAAAAAA+g="
@@ -1382,7 +1386,8 @@ class TestClaimPredicate:
         predicate_rel = ClaimPredicate.predicate_before_relative_time(1000)
         predicate = ClaimPredicate.predicate_and(predicate_abs, predicate_rel)
         assert xdr == self.to_xdr(predicate)
-        assert predicate == ClaimPredicate.from_xdr_object(predicate.to_xdr_object())
+        xdr_object = XdrClaimPredicate.from_xdr(xdr)
+        assert predicate == ClaimPredicate.from_xdr_object(xdr_object)
 
     def test_predicate_and_2(self):
         xdr = "AAAAAQAAAAIAAAAFAAAAAAAAA+gAAAAEAAAAAF9zSqI="
@@ -1390,7 +1395,8 @@ class TestClaimPredicate:
         predicate_rel = ClaimPredicate.predicate_before_relative_time(1000)
         predicate = ClaimPredicate.predicate_and(predicate_rel, predicate_abs)
         assert xdr == self.to_xdr(predicate)
-        assert predicate == ClaimPredicate.from_xdr_object(predicate.to_xdr_object())
+        xdr_object = XdrClaimPredicate.from_xdr(xdr)
+        assert predicate == ClaimPredicate.from_xdr_object(xdr_object)
 
     def test_predicate_or_1(self):
         xdr = "AAAAAgAAAAIAAAAEAAAAAF9zSqIAAAAFAAAAAAAAA+g="
@@ -1398,7 +1404,8 @@ class TestClaimPredicate:
         predicate_rel = ClaimPredicate.predicate_before_relative_time(1000)
         predicate = ClaimPredicate.predicate_or(predicate_abs, predicate_rel)
         assert xdr == self.to_xdr(predicate)
-        assert predicate == ClaimPredicate.from_xdr_object(predicate.to_xdr_object())
+        xdr_object = XdrClaimPredicate.from_xdr(xdr)
+        assert predicate == ClaimPredicate.from_xdr_object(xdr_object)
 
     def test_predicate_or_2(self):
         xdr = "AAAAAgAAAAIAAAAFAAAAAAAAA+gAAAAEAAAAAF9zSqI="
@@ -1406,7 +1413,8 @@ class TestClaimPredicate:
         predicate_rel = ClaimPredicate.predicate_before_relative_time(1000)
         predicate = ClaimPredicate.predicate_or(predicate_rel, predicate_abs)
         assert xdr == self.to_xdr(predicate)
-        assert predicate == ClaimPredicate.from_xdr_object(predicate.to_xdr_object())
+        xdr_object = XdrClaimPredicate.from_xdr(xdr)
+        assert predicate == ClaimPredicate.from_xdr_object(xdr_object)
 
     def test_predicate_mix(self):
         xdr = "AAAAAQAAAAIAAAABAAAAAgAAAAQAAAAAX14QAAAAAAAAAAACAAAAAgAAAAUAAAAAAADDUAAAAAMAAAABAAAABAAAAABlU/EA"
@@ -1422,7 +1430,8 @@ class TestClaimPredicate:
         )
         predicate = ClaimPredicate.predicate_and(predicate_left, predicate_right)
         assert xdr == self.to_xdr(predicate)
-        assert predicate == ClaimPredicate.from_xdr_object(predicate.to_xdr_object())
+        xdr_object = XdrClaimPredicate.from_xdr(xdr)
+        assert predicate == ClaimPredicate.from_xdr_object(xdr_object)
 
     def test_predicate_invalid_type_raise(self):
         predicate = ClaimPredicate(


### PR DESCRIPTION
See #464

`not_predicate` is optional, we did not notice this, which caused the SDK to fail to parse the `not_predicate` properly.