### PR TITLE
refactor: change the type of `FeeBumpTransaction.fee_source` and `Transaction.source` from `Keypair` to `str`

### DIFF
--- a/stellar_sdk/fee_bump_transaction.py
+++ b/stellar_sdk/fee_bump_transaction.py
@@ -53,8 +53,8 @@ class FeeBumpTransaction:
             )
 
     @property
-    def fee_source(self) -> Keypair:
-        return self._fee_source
+    def fee_source(self) -> str:
+        return self._fee_source.public_key
 
     @fee_source.setter
     def fee_source(self, value: Union[Keypair, str]):

--- a/stellar_sdk/sep/stellar_web_authentication.py
+++ b/stellar_sdk/sep/stellar_web_authentication.py
@@ -148,7 +148,7 @@ def read_challenge_transaction(
     transaction = transaction_envelope.transaction
 
     # verify that transaction source account is equal to the server's signing key
-    if transaction.source.public_key != server_account_id:
+    if transaction.source != server_account_id:
         raise InvalidSep10ChallengeError(
             "Transaction source account is not equal to server's account."
         )

--- a/stellar_sdk/sep/txrep.py
+++ b/stellar_sdk/sep/txrep.py
@@ -79,7 +79,7 @@ def to_txrep(
         assert isinstance(fee_bump_transaction, FeeBumpTransaction)
         assert isinstance(transaction, Transaction)
         _add_line(
-            "feeBump.tx.feeSource", fee_bump_transaction.fee_source.public_key, lines
+            "feeBump.tx.feeSource", fee_bump_transaction.fee_source, lines
         )
         _add_line(
             "feeBump.tx.fee",
@@ -90,7 +90,7 @@ def to_txrep(
             "feeBump.tx.innerTx.type", _EnvelopeType.ENVELOPE_TYPE_TX.value, lines
         )
     assert isinstance(transaction, Transaction)
-    _add_line(f"{prefix}sourceAccount", transaction.source.public_key, lines)
+    _add_line(f"{prefix}sourceAccount", transaction.source, lines)
     _add_line(f"{prefix}fee", transaction.fee, lines)
     _add_line(f"{prefix}seqNum", transaction.sequence, lines)
     _add_time_bounds(transaction.time_bounds, prefix, lines)

--- a/stellar_sdk/transaction.py
+++ b/stellar_sdk/transaction.py
@@ -77,8 +77,8 @@ class Transaction:
         self.v1 = v1
 
     @property
-    def source(self) -> Keypair:
-        return self._source
+    def source(self) -> str:
+        return self._source.public_key
 
     @source.setter
     def source(self, value: Union[Keypair, str]):
@@ -107,7 +107,7 @@ class Transaction:
             if self._source_muxed is not None:
                 source_xdr = self._source_muxed
             else:
-                source_xdr = self.source.xdr_muxed_account()
+                source_xdr = self._source.xdr_muxed_account()
             ext = stellar_xdr.TransactionExt(0)
             return stellar_xdr.Transaction(
                 source_xdr,
@@ -118,7 +118,7 @@ class Transaction:
                 operations,
                 ext,
             )
-        source_xdr_v0 = self.source.xdr_public_key().ed25519
+        source_xdr_v0 = self._source.xdr_public_key().ed25519
         assert source_xdr_v0 is not None
         ext_v0 = stellar_xdr.TransactionV0Ext(0)
         return stellar_xdr.TransactionV0(

--- a/stellar_sdk/transaction_builder.py
+++ b/stellar_sdk/transaction_builder.py
@@ -150,7 +150,7 @@ class TransactionBuilder:
         )
 
         source_account = Account(
-            transaction_envelope.transaction.source.public_key,
+            transaction_envelope.transaction.source,
             transaction_envelope.transaction.sequence - 1,
         )
         transaction_builder = TransactionBuilder(

--- a/tests/sep/test_stellar_web_authentication.py
+++ b/tests/sep/test_stellar_web_authentication.py
@@ -63,7 +63,7 @@ class TestStellarWebAuthentication:
             transaction.time_bounds.max_time - transaction.time_bounds.min_time
             == timeout
         )
-        assert transaction.source.public_key == server_kp.public_key
+        assert transaction.source == server_kp.public_key
         assert transaction.sequence == 0
 
     def test_challenge_transaction_with_client_domain(self):
@@ -116,7 +116,7 @@ class TestStellarWebAuthentication:
             transaction.time_bounds.max_time - transaction.time_bounds.min_time
             == timeout
         )
-        assert transaction.source.public_key == server_kp.public_key
+        assert transaction.source == server_kp.public_key
         assert transaction.sequence == 0
 
     def test_challenge_transaction_with_client_domain_fails_without_client_signing_key(self):

--- a/tests/test_fee_bump_transaction.py
+++ b/tests/test_fee_bump_transaction.py
@@ -60,7 +60,7 @@ class TestFeeBumpTransaction:
         )
         restore_tx = restore_te.transaction
         assert isinstance(restore_tx, FeeBumpTransaction)
-        assert restore_tx.fee_source.public_key == fee_source.public_key
+        assert restore_tx.fee_source == fee_source.public_key
         assert restore_tx.base_fee == base_fee
         assert restore_tx.inner_transaction_envelope.to_xdr() == inner_tx.to_xdr()
 
@@ -117,7 +117,7 @@ class TestFeeBumpTransaction:
             == fee_source.xdr_muxed_account().to_xdr()
         )
         restore_te.transaction.fee_source = fee_source2.public_key
-        assert restore_te.transaction.fee_source.public_key == fee_source2.public_key
+        assert restore_te.transaction.fee_source == fee_source2.public_key
         assert restore_te.transaction._fee_source_muxed is None
 
     def test_tx_v0(self):
@@ -169,7 +169,7 @@ class TestFeeBumpTransaction:
         assert restore_tx.inner_transaction_envelope.transaction.v1 is True
         assert inner_tx.transaction.v1 is False
         assert isinstance(restore_tx, FeeBumpTransaction)
-        assert restore_tx.fee_source.public_key == fee_source.public_key
+        assert restore_tx.fee_source == fee_source.public_key
         assert restore_tx.base_fee == base_fee
         assert restore_tx.inner_transaction_envelope.hash() == inner_tx.hash()
 

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -26,7 +26,7 @@ class TestTransaction:
 
         restore_transaction = Transaction.from_xdr_object(tx_object, v1=True)
         assert isinstance(restore_transaction, Transaction)
-        assert restore_transaction.source == Keypair.from_public_key(source.public_key)
+        assert restore_transaction.source == source.public_key
         assert restore_transaction.fee == fee
         assert restore_transaction.memo == memo
         assert restore_transaction.time_bounds == time_bounds
@@ -51,7 +51,7 @@ class TestTransaction:
 
         restore_transaction = Transaction.from_xdr(xdr, True)
         assert isinstance(restore_transaction, Transaction)
-        assert restore_transaction.source == Keypair.from_public_key(source)
+        assert restore_transaction.source == source
         assert restore_transaction.fee == fee
         assert restore_transaction.memo == memo
         assert restore_transaction.time_bounds == time_bounds
@@ -74,14 +74,14 @@ class TestTransaction:
         tx_object = tx.to_xdr_object()
         restore_tx = Transaction.from_xdr_object(tx_object, v1=True)
         assert restore_tx.to_xdr_object().to_xdr() == tx_object.to_xdr()
-        assert restore_tx.source == Keypair.from_public_key(source)
+        assert restore_tx.source == source
         assert (
             restore_tx._source_muxed.to_xdr()
             == Keypair.from_public_key(source).xdr_muxed_account().to_xdr()
         )
         assert restore_tx == tx
         restore_tx.source = source2
-        assert restore_tx.source == Keypair.from_public_key(source2)
+        assert restore_tx.source == source2
         assert restore_tx._source_muxed is None
         assert restore_tx != tx
 
@@ -116,7 +116,7 @@ class TestTransaction:
 
         restore_transaction = Transaction.from_xdr_object(tx_object, False)
         assert isinstance(restore_transaction, Transaction)
-        assert restore_transaction.source == source
+        assert restore_transaction.source == source.public_key
         assert restore_transaction.fee == fee
         assert restore_transaction.memo == memo
         assert restore_transaction.time_bounds == time_bounds
@@ -142,7 +142,7 @@ class TestTransaction:
 
         restore_transaction = Transaction.from_xdr(tx_object.to_xdr(), False)
         assert isinstance(restore_transaction, Transaction)
-        assert restore_transaction.source == Keypair.from_public_key(source)
+        assert restore_transaction.source == source
         assert restore_transaction.fee == fee
         assert restore_transaction.memo == memo
         assert restore_transaction.time_bounds == time_bounds


### PR DESCRIPTION
resolve #433

One reason why we made this change is to make it consistent with `Operation.source`(#433). Another reason is that we are going to add support for SEP-23, so we need to add a new type - `MuxedAccount`, after this `str` will represent ed25519 public key, and `MuxedAccount` will represent muxed account. 

for example `Transaction.source`'s type will be `Union[str, MuxedAccount]`, when `Transaction.source` is `str`, it must be an ed25519 address starting with `G`.