### PR TITLE
SEP-10: Add muxed account and memo support

### DIFF
--- a/stellar_sdk/sep/stellar_web_authentication.py
+++ b/stellar_sdk/sep/stellar_web_authentication.py
@@ -14,6 +14,7 @@ from typing import Iterable, List, Optional, Union
 
 from .. import xdr as stellar_xdr
 from ..account import Account
+from ..memo import IdMemo, NoneMemo
 from ..exceptions import BadSignatureError, ValueError
 from ..keypair import Keypair
 from ..operation.manage_data import ManageData
@@ -41,6 +42,7 @@ class ChallengeTransaction:
     :param transaction: The TransactionEnvelope parsed from challenge xdr.
     :param client_account_id: The stellar account that the wallet wishes to authenticate with the server.
     :param matched_home_domain: The domain name that has been matched.
+    :param memo: The ID memo attached to the transaction
     """
 
     def __init__(
@@ -48,10 +50,12 @@ class ChallengeTransaction:
         transaction: TransactionEnvelope,
         client_account_id: str,
         matched_home_domain: str,
+        memo: Union[int, IdMemo] = None
     ) -> None:
         self.transaction = transaction
         self.client_account_id = client_account_id
         self.matched_home_domain = matched_home_domain
+        self.memo = memo if not isinstance(memo, int) else IdMemo(memo)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):
@@ -60,10 +64,11 @@ class ChallengeTransaction:
             self.transaction == other.transaction
             and self.client_account_id == other.client_account_id
             and self.matched_home_domain == other.matched_home_domain
+            and self.memo == other.memo
         )
 
     def __str__(self):
-        return f"<ChallengeTransaction [transaction={self.transaction}, client_account_id={self.client_account_id}, matched_home_domain={self.matched_home_domain}]>"
+        return f"<ChallengeTransaction [transaction={self.transaction}, client_account_id={self.client_account_id}, memo={self.memo}, matched_home_domain={self.matched_home_domain}]>"
 
 
 def build_challenge_transaction(
@@ -75,12 +80,13 @@ def build_challenge_transaction(
     timeout: int = 900,
     client_domain: Optional[str] = None,
     client_signing_key: Optional[str] = None,
+    memo: Optional[Union[int, IdMemo]] = None
 ) -> str:
     """Returns a valid `SEP0010 <https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md>`_
     challenge transaction which you can use for Stellar Web Authentication.
 
     :param server_secret: secret key for server's stellar.toml `SIGNING_KEY`.
-    :param client_account_id: The stellar account that the wallet wishes to authenticate with the server.
+    :param client_account_id: The stellar account (`G...`) or muxed account (`M...`) that the wallet wishes to authenticate with the server.
     :param home_domain: The `fully qualified domain name <https://en.wikipedia.org/wiki/Fully_qualified_home_domain>`_
         of the service requiring authentication, for example: `example.com`.
     :param web_auth_domain: The fully qualified domain name of the service issuing the challenge.
@@ -89,12 +95,15 @@ def build_challenge_transaction(
     :param timeout: Challenge duration in seconds (default to 15 minutes).
     :param client_domain: The domain of the client application requesting authentication
     :param client_signing_key: The stellar account listed as the SIGNING_KEY on the client domain's TOML file
+    :param memo: The ID memo to attach to the transaction. Not permitted if `client_account_id` is a muxed account
     :return: A base64 encoded string of the raw TransactionEnvelope xdr struct for the transaction.
     """
-    if client_account_id.startswith(MUXED_ACCOUNT_STARTING_LETTER):
+    if client_account_id.startswith(MUXED_ACCOUNT_STARTING_LETTER) and memo:
         raise ValueError(
-            "Invalid client_account_id, multiplexed account are not supported."
+            "memos are not valid for challenge transactions with a muxed client account"
         )
+    if memo and not isinstance(memo, IdMemo):
+        memo = IdMemo(memo)
 
     now = int(time.time())
     server_keypair = Keypair.from_secret(server_secret)
@@ -122,6 +131,8 @@ def build_challenge_transaction(
             data_value=client_domain,
             source=client_signing_key,
         )
+    if memo:
+        transaction_builder.add_memo(memo)
     transaction = transaction_builder.build()
     transaction.sign(server_keypair)
     return transaction.to_xdr()
@@ -253,6 +264,19 @@ def read_challenge_transaction(
             "Operation value before encoding as base64 should be 48 bytes long."
         )
 
+    if not transaction.memo or isinstance(transaction.memo, NoneMemo):
+        memo = None
+    elif client_account.account_muxed_id:
+        raise InvalidSep10ChallengeError(
+            "Invalid challenge, memos are not permitted if the client account is muxed"
+        )
+    elif isinstance(transaction.memo, IdMemo):
+        memo = transaction.memo
+    else:
+        raise InvalidSep10ChallengeError(
+            "Invalid memo, only ID memos are permitted"
+        )
+
     # verify any subsequent operations are manage data ops and source account is the server
     for op in transaction.operations[1:]:
         if not isinstance(op, ManageData):
@@ -283,7 +307,10 @@ def read_challenge_transaction(
         )
 
     return ChallengeTransaction(
-        transaction_envelope, client_account.account_id, matched_home_domain
+        transaction=transaction_envelope,
+        client_account_id=client_account.account_id,
+        matched_home_domain=matched_home_domain,
+        memo=memo
     )
 
 

--- a/stellar_sdk/sep/stellar_web_authentication.py
+++ b/stellar_sdk/sep/stellar_web_authentication.py
@@ -306,14 +306,9 @@ def read_challenge_transaction(
             f"Transaction not signed by server: {server_account_id}."
         )
 
-    if client_account.account_muxed_id:
-        client_account_id = client_account.account_muxed
-    else:
-        client_account_id = client_account.account_id
-
     return ChallengeTransaction(
         transaction=transaction_envelope,
-        client_account_id=client_account_id,
+        client_account_id=client_account.account_muxed or client_account.account_id,
         matched_home_domain=matched_home_domain,
         memo=memo
     )

--- a/tests/sep/test_stellar_web_authentication.py
+++ b/tests/sep/test_stellar_web_authentication.py
@@ -7,7 +7,7 @@ import pytest
 
 from stellar_sdk import Account, Keypair, MuxedAccount, Network
 from stellar_sdk.memo import IdMemo
-from stellar_sdk.exceptions import ValueError, MemoInvalidException
+from stellar_sdk.exceptions import ValueError
 from stellar_sdk.operation import ManageData
 from stellar_sdk.sep.ed25519_public_key_signer import Ed25519PublicKeySigner
 from stellar_sdk.sep.exceptions import InvalidSep10ChallengeError

--- a/tests/sep/test_stellar_web_authentication.py
+++ b/tests/sep/test_stellar_web_authentication.py
@@ -116,6 +116,26 @@ class TestStellarWebAuthentication:
         ).transaction
         assert transaction.memo == IdMemo(memo)
 
+    def test_challenge_transaction_non_id_memo_not_permitted(self):
+        server_kp = Keypair.random()
+        client_account_id = Keypair.random().public_key
+        memo = "test"
+        timeout = 600
+        network_passphrase = Network.TESTNET_NETWORK_PASSPHRASE
+        home_domain = "example.com"
+        web_auth_domain = "auth.example.com"
+
+        with pytest.raises(ValueError, match="memo must be an integer"):
+            build_challenge_transaction(
+                server_secret=server_kp.secret,
+                client_account_id=client_account_id,
+                home_domain=home_domain,
+                web_auth_domain=web_auth_domain,
+                network_passphrase=network_passphrase,
+                timeout=timeout,
+                memo=memo
+            )
+
     def test_challenge_transaction_muxed_client_account_with_memo_not_permitted(self):
         server_kp = Keypair.random()
         client_account_id = (

--- a/tests/sep/test_stellar_web_authentication.py
+++ b/tests/sep/test_stellar_web_authentication.py
@@ -116,36 +116,12 @@ class TestStellarWebAuthentication:
         ).transaction
         assert transaction.memo == IdMemo(memo)
 
-    def test_challenge_transaction_id_memo_as_memo_permitted(self):
-        server_kp = Keypair.random()
-        client_account_id = Keypair.random().public_key
-        memo = IdMemo(randrange(0, 2**64))
-        timeout = 600
-        network_passphrase = Network.TESTNET_NETWORK_PASSPHRASE
-        home_domain = "example.com"
-        web_auth_domain = "auth.example.com"
-
-        challenge = build_challenge_transaction(
-            server_secret=server_kp.secret,
-            client_account_id=client_account_id,
-            home_domain=home_domain,
-            web_auth_domain=web_auth_domain,
-            network_passphrase=network_passphrase,
-            timeout=timeout,
-            memo=memo
-        )
-
-        transaction = TransactionEnvelope.from_xdr(
-            challenge, network_passphrase
-        ).transaction
-        assert transaction.memo == memo
-
     def test_challenge_transaction_muxed_client_account_with_memo_not_permitted(self):
         server_kp = Keypair.random()
         client_account_id = (
             "MAAAAAAAAAAAJURAAB2X52XFQP6FBXLGT6LWOOWMEXWHEWBDVRZ7V5WH34Y22MPFBHUHY"
         )
-        memo = IdMemo(randrange(0, 2**64))
+        memo = randrange(0, 2**64)
         timeout = 600
         network_passphrase = Network.TESTNET_NETWORK_PASSPHRASE
         home_domain = "example.com"
@@ -1791,11 +1767,145 @@ class TestStellarWebAuthentication:
             match="Invalid server_account_id, multiplexed account are not supported.",
         ):
             read_challenge_transaction(
-                challenge,
-                "MAAAAAAAAAAAJURAAB2X52XFQP6FBXLGT6LWOOWMEXWHEWBDVRZ7V5WH34Y22MPFBHUHY",
-                network_passphrase,
-                web_auth_domain,
-                home_domain,
+                challenge_transaction=challenge,
+                server_account_id="MAAAAAAAAAAAJURAAB2X52XFQP6FBXLGT6LWOOWMEXWHEWBDVRZ7V5WH34Y22MPFBHUHY",
+                network_passphrase=network_passphrase,
+                web_auth_domain=web_auth_domain,
+                home_domains=home_domain,
+            )
+
+    def test_read_challenge_transaction_mux_client_id_permitted(self):
+        server_kp = Keypair.random()
+        client_account_id = (
+            "MAAAAAAAAAAAJURAAB2X52XFQP6FBXLGT6LWOOWMEXWHEWBDVRZ7V5WH34Y22MPFBHUHY"
+        )
+        timeout = 600
+        network_passphrase = Network.PUBLIC_NETWORK_PASSPHRASE
+        home_domain = "example.com"
+        web_auth_domain = "auth.example.com"
+
+        challenge = build_challenge_transaction(
+            server_secret=server_kp.secret,
+            client_account_id=client_account_id,
+            home_domain=home_domain,
+            web_auth_domain=web_auth_domain,
+            network_passphrase=network_passphrase,
+            timeout=timeout,
+        )
+        challenge_transaction = read_challenge_transaction(
+            challenge_transaction=challenge,
+            server_account_id=server_kp.public_key,
+            network_passphrase=network_passphrase,
+            web_auth_domain=web_auth_domain,
+            home_domains=home_domain,
+        )
+        assert challenge_transaction.client_account_id == client_account_id
+
+    def test_read_challenge_transaction_with_memo_permitted(self):
+        server_kp = Keypair.random()
+        client_account_id = Keypair.random()
+        timeout = 600
+        network_passphrase = Network.PUBLIC_NETWORK_PASSPHRASE
+        home_domain = "example.com"
+        web_auth_domain = "auth.example.com"
+        memo = randrange(0, 2**64)
+
+        challenge = build_challenge_transaction(
+            server_secret=server_kp.secret,
+            client_account_id=client_account_id.public_key,
+            home_domain=home_domain,
+            web_auth_domain=web_auth_domain,
+            network_passphrase=network_passphrase,
+            timeout=timeout,
+            memo=memo
+        )
+        challenge_transaction = read_challenge_transaction(
+            challenge_transaction=challenge,
+            server_account_id=server_kp.public_key,
+            network_passphrase=network_passphrase,
+            web_auth_domain=web_auth_domain,
+            home_domains=home_domain,
+        )
+        assert challenge_transaction.memo == memo
+
+    def test_read_challenge_transaction_mux_client_id_with_memo_not_permitted(self):
+        server_account = Account(Keypair.random().public_key, -1)
+        client_account_id = (
+            "MAAAAAAAAAAAJURAAB2X52XFQP6FBXLGT6LWOOWMEXWHEWBDVRZ7V5WH34Y22MPFBHUHY"
+        )
+        timeout = 600
+        network_passphrase = Network.PUBLIC_NETWORK_PASSPHRASE
+        home_domain = "example.com"
+        web_auth_domain = "auth.example.com"
+        nonce = os.urandom(48)
+        nonce_encoded = base64.b64encode(nonce)
+
+        challenge = TransactionBuilder(
+            source_account=server_account,
+            network_passphrase=network_passphrase
+        ).append_manage_data_op(
+            data_name=f"{home_domain} auth",
+            data_value=nonce_encoded,
+            source=client_account_id
+        ).append_manage_data_op(
+            data_name="web_auth_domain",
+            data_value=home_domain,
+            source=server_account.account,
+        ).add_id_memo(
+            randrange(0, 2**64)
+        ).set_timeout(
+            timeout
+        ).build()
+
+        with pytest.raises(
+            InvalidSep10ChallengeError,
+            match="Invalid challenge, memos are not permitted if the client account is muxed"
+        ):
+            read_challenge_transaction(
+                challenge_transaction=challenge.to_xdr(),
+                server_account_id=server_account.account.account_id,
+                network_passphrase=network_passphrase,
+                web_auth_domain=web_auth_domain,
+                home_domains=home_domain,
+            )
+
+    def test_read_challenge_transaction_with_non_id_memo_not_permitted(self):
+        server_account = Account(Keypair.random().public_key, -1)
+        client_account_id = Keypair.random().public_key
+        timeout = 600
+        network_passphrase = Network.PUBLIC_NETWORK_PASSPHRASE
+        home_domain = "example.com"
+        web_auth_domain = "auth.example.com"
+        nonce = os.urandom(48)
+        nonce_encoded = base64.b64encode(nonce)
+
+        challenge = TransactionBuilder(
+            source_account=server_account,
+            network_passphrase=network_passphrase
+        ).append_manage_data_op(
+            data_name=f"{home_domain} auth",
+            data_value=nonce_encoded,
+            source=client_account_id
+        ).append_manage_data_op(
+            data_name="web_auth_domain",
+            data_value=home_domain,
+            source=server_account.account,
+        ).add_text_memo(
+            "test"
+        ).set_timeout(
+            timeout
+        ).build()
+
+        with pytest.raises(
+            InvalidSep10ChallengeError,
+            match="Invalid memo, only ID memos are permitted"
+        ):
+            read_challenge_transaction(
+                challenge_transaction=challenge.to_xdr(),
+                server_account_id=server_account.account.account_id,
+                network_passphrase=network_passphrase,
+                web_auth_domain=web_auth_domain,
+                home_domains=home_domain,
             )
 
     def test_read_challenge_transaction_fee_bump_transaction_raise(self):


### PR DESCRIPTION
Allows muxed accounts to be passed for `client_account_id` and adds a `memo` parameter to `ChallengeTransaction` and `build_challenge_transaction()`. These changes implement the specification's update for pooled/shared/omnibus account support: [#1036](https://github.com/stellar/stellar-protocol/pull/1036).

These changes should be backported to all major versions that have the `ChallengeTransaction` class.