### PR TITLE
SEP-10: check for muxed accounts in `verify_challenge_transaction()`

### DIFF
--- a/stellar_sdk/sep/stellar_web_authentication.py
+++ b/stellar_sdk/sep/stellar_web_authentication.py
@@ -13,8 +13,9 @@ import time
 from typing import Iterable, List, Optional, Union
 
 from .. import xdr as stellar_xdr
-from ..account import Account
 from ..memo import IdMemo, NoneMemo
+from ..account import Account
+from ..muxed_account import MuxedAccount
 from ..exceptions import BadSignatureError, ValueError
 from ..keypair import Keypair
 from ..operation.manage_data import ManageData
@@ -547,6 +548,8 @@ def verify_challenge_transaction(
         network_passphrase,
     )
     client_account_id = parsed_challenge_transaction.client_account_id
+    if client_account_id.startswith(MUXED_ACCOUNT_STARTING_LETTER):
+        client_account_id = MuxedAccount.from_account(client_account_id).account_id
     signers = [Ed25519PublicKeySigner(client_account_id, 255)]
     verify_challenge_transaction_signers(
         challenge_transaction,

--- a/tests/sep/test_stellar_web_authentication.py
+++ b/tests/sep/test_stellar_web_authentication.py
@@ -267,6 +267,35 @@ class TestStellarWebAuthentication:
             network_passphrase,
         )
 
+    def test_verify_challenge_transaction_muxed_client_account(self):
+        server_kp = Keypair.random()
+        client_kp = Keypair.random()
+        client_muxed_account = MuxedAccount(client_kp.public_key, 123).account_muxed
+        timeout = 600
+        network_passphrase = Network.PUBLIC_NETWORK_PASSPHRASE
+        home_domain = "example.com"
+        web_auth_domain = "auth.example.com"
+
+        challenge = build_challenge_transaction(
+            server_secret=server_kp.secret,
+            client_account_id=client_muxed_account,
+            home_domain=home_domain,
+            web_auth_domain=web_auth_domain,
+            network_passphrase=network_passphrase,
+            timeout=timeout,
+        )
+
+        transaction = TransactionEnvelope.from_xdr(challenge, network_passphrase)
+        transaction.sign(client_kp)
+        challenge_tx = transaction.to_xdr()
+        verify_challenge_transaction(
+            challenge_tx,
+            server_kp.public_key,
+            home_domain,
+            web_auth_domain,
+            network_passphrase,
+        )
+
     def test_verify_challenge_transaction_with_multi_domain_names(self):
         server_kp = Keypair.random()
         client_kp = Keypair.random()


### PR DESCRIPTION
I missed another SEP-10 utility function, `verify_challenge_transaction()` that needed to be aware of muxed accounts. 

In Polaris, this function is specifically used when the Stellar account does not exist and therefore only the master signer of the account needs to have signed the challenge. The function needs to check if the `ChallengeTransaction.client_account_id` is a muxed address or not and adjust accordingly.

I believe this will warrant a patch release (4.2.1), sorry for missing this the first time.