### PR TITLE
refactor: remove runtime type checking in `stellar_sdk.xdr` package

### DIFF
--- a/stellar_sdk/xdr/__init__.py
+++ b/stellar_sdk/xdr/__init__.py
@@ -1,4 +1,4 @@
-# Automatically generated on 2022-04-07T14:33:04+08:00
+# Automatically generated on 2022-04-19T08:23:15+08:00
 # DO NOT EDIT or your changes may be overwritten
 from .account_entry import AccountEntry
 from .account_entry_ext import AccountEntryExt

--- a/stellar_sdk/xdr/account_entry.py
+++ b/stellar_sdk/xdr/account_entry.py
@@ -4,7 +4,6 @@ import base64
 from typing import List, Optional
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_entry_ext import AccountEntryExt
 from .account_id import AccountID
 from .constants import *
@@ -18,7 +17,6 @@ from .uint32 import Uint32
 __all__ = ["AccountEntry"]
 
 
-@type_checked
 class AccountEntry:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/account_entry_ext.py
+++ b/stellar_sdk/xdr/account_entry_ext.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_entry_extension_v1 import AccountEntryExtensionV1
 from .base import Integer
 
 __all__ = ["AccountEntryExt"]
 
 
-@type_checked
 class AccountEntryExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/account_entry_extension_v1.py
+++ b/stellar_sdk/xdr/account_entry_extension_v1.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_entry_extension_v1_ext import AccountEntryExtensionV1Ext
 from .liabilities import Liabilities
 
 __all__ = ["AccountEntryExtensionV1"]
 
 
-@type_checked
 class AccountEntryExtensionV1:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/account_entry_extension_v1_ext.py
+++ b/stellar_sdk/xdr/account_entry_extension_v1_ext.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_entry_extension_v2 import AccountEntryExtensionV2
 from .base import Integer
 
 __all__ = ["AccountEntryExtensionV1Ext"]
 
 
-@type_checked
 class AccountEntryExtensionV1Ext:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/account_entry_extension_v2.py
+++ b/stellar_sdk/xdr/account_entry_extension_v2.py
@@ -4,7 +4,6 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_entry_extension_v2_ext import AccountEntryExtensionV2Ext
 from .constants import *
 from .sponsorship_descriptor import SponsorshipDescriptor
@@ -13,7 +12,6 @@ from .uint32 import Uint32
 __all__ = ["AccountEntryExtensionV2"]
 
 
-@type_checked
 class AccountEntryExtensionV2:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/account_entry_extension_v2_ext.py
+++ b/stellar_sdk/xdr/account_entry_extension_v2_ext.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_entry_extension_v3 import AccountEntryExtensionV3
 from .base import Integer
 
 __all__ = ["AccountEntryExtensionV2Ext"]
 
 
-@type_checked
 class AccountEntryExtensionV2Ext:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/account_entry_extension_v3.py
+++ b/stellar_sdk/xdr/account_entry_extension_v3.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .extension_point import ExtensionPoint
 from .time_point import TimePoint
 from .uint32 import Uint32
@@ -11,7 +10,6 @@ from .uint32 import Uint32
 __all__ = ["AccountEntryExtensionV3"]
 
 
-@type_checked
 class AccountEntryExtensionV3:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/account_flags.py
+++ b/stellar_sdk/xdr/account_flags.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["AccountFlags"]
 
 
-@type_checked
 class AccountFlags(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/account_id.py
+++ b/stellar_sdk/xdr/account_id.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .public_key import PublicKey
 
 __all__ = ["AccountID"]
 
 
-@type_checked
 class AccountID:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/account_merge_result.py
+++ b/stellar_sdk/xdr/account_merge_result.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_merge_result_code import AccountMergeResultCode
 from .int64 import Int64
 
 __all__ = ["AccountMergeResult"]
 
 
-@type_checked
 class AccountMergeResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/account_merge_result_code.py
+++ b/stellar_sdk/xdr/account_merge_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["AccountMergeResultCode"]
 
 
-@type_checked
 class AccountMergeResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/allow_trust_op.py
+++ b/stellar_sdk/xdr/allow_trust_op.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .asset_code import AssetCode
 from .uint32 import Uint32
@@ -11,7 +10,6 @@ from .uint32 import Uint32
 __all__ = ["AllowTrustOp"]
 
 
-@type_checked
 class AllowTrustOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/allow_trust_result.py
+++ b/stellar_sdk/xdr/allow_trust_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .allow_trust_result_code import AllowTrustResultCode
 
 __all__ = ["AllowTrustResult"]
 
 
-@type_checked
 class AllowTrustResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/allow_trust_result_code.py
+++ b/stellar_sdk/xdr/allow_trust_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["AllowTrustResultCode"]
 
 
-@type_checked
 class AllowTrustResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/alpha_num12.py
+++ b/stellar_sdk/xdr/alpha_num12.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .asset_code12 import AssetCode12
 
 __all__ = ["AlphaNum12"]
 
 
-@type_checked
 class AlphaNum12:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/alpha_num4.py
+++ b/stellar_sdk/xdr/alpha_num4.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .asset_code4 import AssetCode4
 
 __all__ = ["AlphaNum4"]
 
 
-@type_checked
 class AlphaNum4:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/asset.py
+++ b/stellar_sdk/xdr/asset.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .alpha_num4 import AlphaNum4
 from .alpha_num12 import AlphaNum12
 from .asset_type import AssetType
@@ -11,7 +10,6 @@ from .asset_type import AssetType
 __all__ = ["Asset"]
 
 
-@type_checked
 class Asset:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/asset_code.py
+++ b/stellar_sdk/xdr/asset_code.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset_code4 import AssetCode4
 from .asset_code12 import AssetCode12
 from .asset_type import AssetType
@@ -11,7 +10,6 @@ from .asset_type import AssetType
 __all__ = ["AssetCode"]
 
 
-@type_checked
 class AssetCode:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/asset_code12.py
+++ b/stellar_sdk/xdr/asset_code12.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["AssetCode12"]
 
 
-@type_checked
 class AssetCode12:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/asset_code4.py
+++ b/stellar_sdk/xdr/asset_code4.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["AssetCode4"]
 
 
-@type_checked
 class AssetCode4:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/asset_type.py
+++ b/stellar_sdk/xdr/asset_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["AssetType"]
 
 
-@type_checked
 class AssetType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/auth.py
+++ b/stellar_sdk/xdr/auth.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["Auth"]
 
 
-@type_checked
 class Auth:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/auth_cert.py
+++ b/stellar_sdk/xdr/auth_cert.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .curve25519_public import Curve25519Public
 from .signature import Signature
 from .uint64 import Uint64
@@ -11,7 +10,6 @@ from .uint64 import Uint64
 __all__ = ["AuthCert"]
 
 
-@type_checked
 class AuthCert:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/authenticated_message.py
+++ b/stellar_sdk/xdr/authenticated_message.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .authenticated_message_v0 import AuthenticatedMessageV0
 from .uint32 import Uint32
 
 __all__ = ["AuthenticatedMessage"]
 
 
-@type_checked
 class AuthenticatedMessage:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/authenticated_message_v0.py
+++ b/stellar_sdk/xdr/authenticated_message_v0.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .hmac_sha256_mac import HmacSha256Mac
 from .stellar_message import StellarMessage
 from .uint64 import Uint64
@@ -11,7 +10,6 @@ from .uint64 import Uint64
 __all__ = ["AuthenticatedMessageV0"]
 
 
-@type_checked
 class AuthenticatedMessageV0:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/base.py
+++ b/stellar_sdk/xdr/base.py
@@ -1,7 +1,5 @@
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
-
 __all__ = [
     "Integer",
     "UnsignedInteger",
@@ -15,7 +13,6 @@ __all__ = [
 ]
 
 
-@type_checked
 class Integer:
     def __init__(self, value: int) -> None:
         self.value = value
@@ -36,7 +33,6 @@ class Integer:
         return f"<Integer [value={self.value}]>"
 
 
-@type_checked
 class UnsignedInteger:
     def __init__(self, value: int) -> None:
         self.value = value
@@ -57,7 +53,6 @@ class UnsignedInteger:
         return f"<UnsignedInteger [value={self.value}]>"
 
 
-@type_checked
 class Float:
     def __init__(self, value: float) -> None:
         self.value = value
@@ -78,7 +73,6 @@ class Float:
         return f"<Float [value={self.value}]>"
 
 
-@type_checked
 class Double:
     def __init__(self, value: float) -> None:
         self.value = value
@@ -99,7 +93,6 @@ class Double:
         return f"<Double [value={self.value}]>"
 
 
-@type_checked
 class Hyper:
     def __init__(self, value: int) -> None:
         self.value = value
@@ -120,7 +113,6 @@ class Hyper:
         return f"<Hyper [value={self.value}]>"
 
 
-@type_checked
 class UnsignedHyper:
     def __init__(self, value: int) -> None:
         self.value = value
@@ -141,7 +133,6 @@ class UnsignedHyper:
         return f"<UnsignedHyper [value={self.value}]>"
 
 
-@type_checked
 class Boolean:
     def __init__(self, value: bool) -> None:
         self.value = value
@@ -162,7 +153,6 @@ class Boolean:
         return f"<Boolean [value={self.value}]>"
 
 
-@type_checked
 class String:
     def __init__(self, value: bytes, size: int) -> None:
         if len(value) > size:
@@ -191,7 +181,6 @@ class String:
         return f"<String [value={self.value}, size={self.size}]>"
 
 
-@type_checked
 class Opaque:
     def __init__(self, value: bytes, size: int, fixed: bool) -> None:
         if fixed:

--- a/stellar_sdk/xdr/begin_sponsoring_future_reserves_op.py
+++ b/stellar_sdk/xdr/begin_sponsoring_future_reserves_op.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 
 __all__ = ["BeginSponsoringFutureReservesOp"]
 
 
-@type_checked
 class BeginSponsoringFutureReservesOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/begin_sponsoring_future_reserves_result.py
+++ b/stellar_sdk/xdr/begin_sponsoring_future_reserves_result.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .begin_sponsoring_future_reserves_result_code import (
     BeginSponsoringFutureReservesResultCode,
 )
@@ -11,7 +10,6 @@ from .begin_sponsoring_future_reserves_result_code import (
 __all__ = ["BeginSponsoringFutureReservesResult"]
 
 
-@type_checked
 class BeginSponsoringFutureReservesResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/begin_sponsoring_future_reserves_result_code.py
+++ b/stellar_sdk/xdr/begin_sponsoring_future_reserves_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["BeginSponsoringFutureReservesResultCode"]
 
 
-@type_checked
 class BeginSponsoringFutureReservesResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/bucket_entry.py
+++ b/stellar_sdk/xdr/bucket_entry.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .bucket_entry_type import BucketEntryType
 from .bucket_metadata import BucketMetadata
 from .ledger_entry import LedgerEntry
@@ -12,7 +11,6 @@ from .ledger_key import LedgerKey
 __all__ = ["BucketEntry"]
 
 
-@type_checked
 class BucketEntry:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/bucket_entry_type.py
+++ b/stellar_sdk/xdr/bucket_entry_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["BucketEntryType"]
 
 
-@type_checked
 class BucketEntryType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/bucket_metadata.py
+++ b/stellar_sdk/xdr/bucket_metadata.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .bucket_metadata_ext import BucketMetadataExt
 from .uint32 import Uint32
 
 __all__ = ["BucketMetadata"]
 
 
-@type_checked
 class BucketMetadata:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/bucket_metadata_ext.py
+++ b/stellar_sdk/xdr/bucket_metadata_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["BucketMetadataExt"]
 
 
-@type_checked
 class BucketMetadataExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/bump_sequence_op.py
+++ b/stellar_sdk/xdr/bump_sequence_op.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .sequence_number import SequenceNumber
 
 __all__ = ["BumpSequenceOp"]
 
 
-@type_checked
 class BumpSequenceOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/bump_sequence_result.py
+++ b/stellar_sdk/xdr/bump_sequence_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .bump_sequence_result_code import BumpSequenceResultCode
 
 __all__ = ["BumpSequenceResult"]
 
 
-@type_checked
 class BumpSequenceResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/bump_sequence_result_code.py
+++ b/stellar_sdk/xdr/bump_sequence_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["BumpSequenceResultCode"]
 
 
-@type_checked
 class BumpSequenceResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/change_trust_asset.py
+++ b/stellar_sdk/xdr/change_trust_asset.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .alpha_num4 import AlphaNum4
 from .alpha_num12 import AlphaNum12
 from .asset_type import AssetType
@@ -12,7 +11,6 @@ from .liquidity_pool_parameters import LiquidityPoolParameters
 __all__ = ["ChangeTrustAsset"]
 
 
-@type_checked
 class ChangeTrustAsset:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/change_trust_op.py
+++ b/stellar_sdk/xdr/change_trust_op.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .change_trust_asset import ChangeTrustAsset
 from .int64 import Int64
 
 __all__ = ["ChangeTrustOp"]
 
 
-@type_checked
 class ChangeTrustOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/change_trust_result.py
+++ b/stellar_sdk/xdr/change_trust_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .change_trust_result_code import ChangeTrustResultCode
 
 __all__ = ["ChangeTrustResult"]
 
 
-@type_checked
 class ChangeTrustResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/change_trust_result_code.py
+++ b/stellar_sdk/xdr/change_trust_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ChangeTrustResultCode"]
 
 
-@type_checked
 class ChangeTrustResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claim_atom.py
+++ b/stellar_sdk/xdr/claim_atom.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .claim_atom_type import ClaimAtomType
 from .claim_liquidity_atom import ClaimLiquidityAtom
 from .claim_offer_atom import ClaimOfferAtom
@@ -12,7 +11,6 @@ from .claim_offer_atom_v0 import ClaimOfferAtomV0
 __all__ = ["ClaimAtom"]
 
 
-@type_checked
 class ClaimAtom:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claim_atom_type.py
+++ b/stellar_sdk/xdr/claim_atom_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ClaimAtomType"]
 
 
-@type_checked
 class ClaimAtomType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claim_claimable_balance_op.py
+++ b/stellar_sdk/xdr/claim_claimable_balance_op.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .claimable_balance_id import ClaimableBalanceID
 
 __all__ = ["ClaimClaimableBalanceOp"]
 
 
-@type_checked
 class ClaimClaimableBalanceOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claim_claimable_balance_result.py
+++ b/stellar_sdk/xdr/claim_claimable_balance_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .claim_claimable_balance_result_code import ClaimClaimableBalanceResultCode
 
 __all__ = ["ClaimClaimableBalanceResult"]
 
 
-@type_checked
 class ClaimClaimableBalanceResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claim_claimable_balance_result_code.py
+++ b/stellar_sdk/xdr/claim_claimable_balance_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ClaimClaimableBalanceResultCode"]
 
 
-@type_checked
 class ClaimClaimableBalanceResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claim_liquidity_atom.py
+++ b/stellar_sdk/xdr/claim_liquidity_atom.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .int64 import Int64
 from .pool_id import PoolID
@@ -11,7 +10,6 @@ from .pool_id import PoolID
 __all__ = ["ClaimLiquidityAtom"]
 
 
-@type_checked
 class ClaimLiquidityAtom:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claim_offer_atom.py
+++ b/stellar_sdk/xdr/claim_offer_atom.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .asset import Asset
 from .int64 import Int64
@@ -11,7 +10,6 @@ from .int64 import Int64
 __all__ = ["ClaimOfferAtom"]
 
 
-@type_checked
 class ClaimOfferAtom:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claim_offer_atom_v0.py
+++ b/stellar_sdk/xdr/claim_offer_atom_v0.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .int64 import Int64
 from .uint256 import Uint256
@@ -11,7 +10,6 @@ from .uint256 import Uint256
 __all__ = ["ClaimOfferAtomV0"]
 
 
-@type_checked
 class ClaimOfferAtomV0:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claim_predicate.py
+++ b/stellar_sdk/xdr/claim_predicate.py
@@ -4,14 +4,12 @@ import base64
 from typing import List, Optional
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .claim_predicate_type import ClaimPredicateType
 from .int64 import Int64
 
 __all__ = ["ClaimPredicate"]
 
 
-@type_checked
 class ClaimPredicate:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claim_predicate_type.py
+++ b/stellar_sdk/xdr/claim_predicate_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ClaimPredicateType"]
 
 
-@type_checked
 class ClaimPredicateType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claimable_balance_entry.py
+++ b/stellar_sdk/xdr/claimable_balance_entry.py
@@ -4,7 +4,6 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .claimable_balance_entry_ext import ClaimableBalanceEntryExt
 from .claimable_balance_id import ClaimableBalanceID
@@ -14,7 +13,6 @@ from .int64 import Int64
 __all__ = ["ClaimableBalanceEntry"]
 
 
-@type_checked
 class ClaimableBalanceEntry:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claimable_balance_entry_ext.py
+++ b/stellar_sdk/xdr/claimable_balance_entry_ext.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 from .claimable_balance_entry_extension_v1 import ClaimableBalanceEntryExtensionV1
 
 __all__ = ["ClaimableBalanceEntryExt"]
 
 
-@type_checked
 class ClaimableBalanceEntryExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claimable_balance_entry_extension_v1.py
+++ b/stellar_sdk/xdr/claimable_balance_entry_extension_v1.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .claimable_balance_entry_extension_v1_ext import (
     ClaimableBalanceEntryExtensionV1Ext,
 )
@@ -12,7 +11,6 @@ from .uint32 import Uint32
 __all__ = ["ClaimableBalanceEntryExtensionV1"]
 
 
-@type_checked
 class ClaimableBalanceEntryExtensionV1:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claimable_balance_entry_extension_v1_ext.py
+++ b/stellar_sdk/xdr/claimable_balance_entry_extension_v1_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["ClaimableBalanceEntryExtensionV1Ext"]
 
 
-@type_checked
 class ClaimableBalanceEntryExtensionV1Ext:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claimable_balance_flags.py
+++ b/stellar_sdk/xdr/claimable_balance_flags.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ClaimableBalanceFlags"]
 
 
-@type_checked
 class ClaimableBalanceFlags(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claimable_balance_id.py
+++ b/stellar_sdk/xdr/claimable_balance_id.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .claimable_balance_id_type import ClaimableBalanceIDType
 from .hash import Hash
 
 __all__ = ["ClaimableBalanceID"]
 
 
-@type_checked
 class ClaimableBalanceID:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claimable_balance_id_type.py
+++ b/stellar_sdk/xdr/claimable_balance_id_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ClaimableBalanceIDType"]
 
 
-@type_checked
 class ClaimableBalanceIDType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claimant.py
+++ b/stellar_sdk/xdr/claimant.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .claimant_type import ClaimantType
 from .claimant_v0 import ClaimantV0
 
 __all__ = ["Claimant"]
 
 
-@type_checked
 class Claimant:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claimant_type.py
+++ b/stellar_sdk/xdr/claimant_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ClaimantType"]
 
 
-@type_checked
 class ClaimantType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/claimant_v0.py
+++ b/stellar_sdk/xdr/claimant_v0.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .claim_predicate import ClaimPredicate
 
 __all__ = ["ClaimantV0"]
 
 
-@type_checked
 class ClaimantV0:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/clawback_claimable_balance_op.py
+++ b/stellar_sdk/xdr/clawback_claimable_balance_op.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .claimable_balance_id import ClaimableBalanceID
 
 __all__ = ["ClawbackClaimableBalanceOp"]
 
 
-@type_checked
 class ClawbackClaimableBalanceOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/clawback_claimable_balance_result.py
+++ b/stellar_sdk/xdr/clawback_claimable_balance_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .clawback_claimable_balance_result_code import ClawbackClaimableBalanceResultCode
 
 __all__ = ["ClawbackClaimableBalanceResult"]
 
 
-@type_checked
 class ClawbackClaimableBalanceResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/clawback_claimable_balance_result_code.py
+++ b/stellar_sdk/xdr/clawback_claimable_balance_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ClawbackClaimableBalanceResultCode"]
 
 
-@type_checked
 class ClawbackClaimableBalanceResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/clawback_op.py
+++ b/stellar_sdk/xdr/clawback_op.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .int64 import Int64
 from .muxed_account import MuxedAccount
@@ -11,7 +10,6 @@ from .muxed_account import MuxedAccount
 __all__ = ["ClawbackOp"]
 
 
-@type_checked
 class ClawbackOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/clawback_result.py
+++ b/stellar_sdk/xdr/clawback_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .clawback_result_code import ClawbackResultCode
 
 __all__ = ["ClawbackResult"]
 
 
-@type_checked
 class ClawbackResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/clawback_result_code.py
+++ b/stellar_sdk/xdr/clawback_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ClawbackResultCode"]
 
 
-@type_checked
 class ClawbackResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/create_account_op.py
+++ b/stellar_sdk/xdr/create_account_op.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .int64 import Int64
 
 __all__ = ["CreateAccountOp"]
 
 
-@type_checked
 class CreateAccountOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/create_account_result.py
+++ b/stellar_sdk/xdr/create_account_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .create_account_result_code import CreateAccountResultCode
 
 __all__ = ["CreateAccountResult"]
 
 
-@type_checked
 class CreateAccountResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/create_account_result_code.py
+++ b/stellar_sdk/xdr/create_account_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["CreateAccountResultCode"]
 
 
-@type_checked
 class CreateAccountResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/create_claimable_balance_op.py
+++ b/stellar_sdk/xdr/create_claimable_balance_op.py
@@ -4,7 +4,6 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .claimant import Claimant
 from .int64 import Int64
@@ -12,7 +11,6 @@ from .int64 import Int64
 __all__ = ["CreateClaimableBalanceOp"]
 
 
-@type_checked
 class CreateClaimableBalanceOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/create_claimable_balance_result.py
+++ b/stellar_sdk/xdr/create_claimable_balance_result.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .claimable_balance_id import ClaimableBalanceID
 from .create_claimable_balance_result_code import CreateClaimableBalanceResultCode
 
 __all__ = ["CreateClaimableBalanceResult"]
 
 
-@type_checked
 class CreateClaimableBalanceResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/create_claimable_balance_result_code.py
+++ b/stellar_sdk/xdr/create_claimable_balance_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["CreateClaimableBalanceResultCode"]
 
 
-@type_checked
 class CreateClaimableBalanceResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/create_passive_sell_offer_op.py
+++ b/stellar_sdk/xdr/create_passive_sell_offer_op.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .int64 import Int64
 from .price import Price
@@ -11,7 +10,6 @@ from .price import Price
 __all__ = ["CreatePassiveSellOfferOp"]
 
 
-@type_checked
 class CreatePassiveSellOfferOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/crypto_key_type.py
+++ b/stellar_sdk/xdr/crypto_key_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["CryptoKeyType"]
 
 
-@type_checked
 class CryptoKeyType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/curve25519_public.py
+++ b/stellar_sdk/xdr/curve25519_public.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["Curve25519Public"]
 
 
-@type_checked
 class Curve25519Public:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/curve25519_secret.py
+++ b/stellar_sdk/xdr/curve25519_secret.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["Curve25519Secret"]
 
 
-@type_checked
 class Curve25519Secret:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/data_entry.py
+++ b/stellar_sdk/xdr/data_entry.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .data_entry_ext import DataEntryExt
 from .data_value import DataValue
@@ -12,7 +11,6 @@ from .string64 import String64
 __all__ = ["DataEntry"]
 
 
-@type_checked
 class DataEntry:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/data_entry_ext.py
+++ b/stellar_sdk/xdr/data_entry_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["DataEntryExt"]
 
 
-@type_checked
 class DataEntryExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/data_value.py
+++ b/stellar_sdk/xdr/data_value.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["DataValue"]
 
 
-@type_checked
 class DataValue:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/decorated_signature.py
+++ b/stellar_sdk/xdr/decorated_signature.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .signature import Signature
 from .signature_hint import SignatureHint
 
 __all__ = ["DecoratedSignature"]
 
 
-@type_checked
 class DecoratedSignature:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/dont_have.py
+++ b/stellar_sdk/xdr/dont_have.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .message_type import MessageType
 from .uint256 import Uint256
 
 __all__ = ["DontHave"]
 
 
-@type_checked
 class DontHave:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/duration.py
+++ b/stellar_sdk/xdr/duration.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .uint64 import Uint64
 
 __all__ = ["Duration"]
 
 
-@type_checked
 class Duration:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/encrypted_body.py
+++ b/stellar_sdk/xdr/encrypted_body.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["EncryptedBody"]
 
 
-@type_checked
 class EncryptedBody:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/end_sponsoring_future_reserves_result.py
+++ b/stellar_sdk/xdr/end_sponsoring_future_reserves_result.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .end_sponsoring_future_reserves_result_code import (
     EndSponsoringFutureReservesResultCode,
 )
@@ -11,7 +10,6 @@ from .end_sponsoring_future_reserves_result_code import (
 __all__ = ["EndSponsoringFutureReservesResult"]
 
 
-@type_checked
 class EndSponsoringFutureReservesResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/end_sponsoring_future_reserves_result_code.py
+++ b/stellar_sdk/xdr/end_sponsoring_future_reserves_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["EndSponsoringFutureReservesResultCode"]
 
 
-@type_checked
 class EndSponsoringFutureReservesResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/envelope_type.py
+++ b/stellar_sdk/xdr/envelope_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["EnvelopeType"]
 
 
-@type_checked
 class EnvelopeType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/error.py
+++ b/stellar_sdk/xdr/error.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import String
 from .error_code import ErrorCode
 
 __all__ = ["Error"]
 
 
-@type_checked
 class Error:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/error_code.py
+++ b/stellar_sdk/xdr/error_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ErrorCode"]
 
 
-@type_checked
 class ErrorCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/extension_point.py
+++ b/stellar_sdk/xdr/extension_point.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["ExtensionPoint"]
 
 
-@type_checked
 class ExtensionPoint:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/fee_bump_transaction.py
+++ b/stellar_sdk/xdr/fee_bump_transaction.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .fee_bump_transaction_ext import FeeBumpTransactionExt
 from .fee_bump_transaction_inner_tx import FeeBumpTransactionInnerTx
 from .int64 import Int64
@@ -12,7 +11,6 @@ from .muxed_account import MuxedAccount
 __all__ = ["FeeBumpTransaction"]
 
 
-@type_checked
 class FeeBumpTransaction:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/fee_bump_transaction_envelope.py
+++ b/stellar_sdk/xdr/fee_bump_transaction_envelope.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .decorated_signature import DecoratedSignature
 from .fee_bump_transaction import FeeBumpTransaction
 
 __all__ = ["FeeBumpTransactionEnvelope"]
 
 
-@type_checked
 class FeeBumpTransactionEnvelope:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/fee_bump_transaction_ext.py
+++ b/stellar_sdk/xdr/fee_bump_transaction_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["FeeBumpTransactionExt"]
 
 
-@type_checked
 class FeeBumpTransactionExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/fee_bump_transaction_inner_tx.py
+++ b/stellar_sdk/xdr/fee_bump_transaction_inner_tx.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .envelope_type import EnvelopeType
 from .transaction_v1_envelope import TransactionV1Envelope
 
 __all__ = ["FeeBumpTransactionInnerTx"]
 
 
-@type_checked
 class FeeBumpTransactionInnerTx:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/hash.py
+++ b/stellar_sdk/xdr/hash.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["Hash"]
 
 
-@type_checked
 class Hash:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/hash_id_preimage.py
+++ b/stellar_sdk/xdr/hash_id_preimage.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .envelope_type import EnvelopeType
 from .hash_id_preimage_operation_id import HashIDPreimageOperationID
 from .hash_id_preimage_revoke_id import HashIDPreimageRevokeID
@@ -11,7 +10,6 @@ from .hash_id_preimage_revoke_id import HashIDPreimageRevokeID
 __all__ = ["HashIDPreimage"]
 
 
-@type_checked
 class HashIDPreimage:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/hash_id_preimage_operation_id.py
+++ b/stellar_sdk/xdr/hash_id_preimage_operation_id.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .sequence_number import SequenceNumber
 from .uint32 import Uint32
@@ -11,7 +10,6 @@ from .uint32 import Uint32
 __all__ = ["HashIDPreimageOperationID"]
 
 
-@type_checked
 class HashIDPreimageOperationID:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/hash_id_preimage_revoke_id.py
+++ b/stellar_sdk/xdr/hash_id_preimage_revoke_id.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .asset import Asset
 from .pool_id import PoolID
@@ -13,7 +12,6 @@ from .uint32 import Uint32
 __all__ = ["HashIDPreimageRevokeID"]
 
 
-@type_checked
 class HashIDPreimageRevokeID:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/hello.py
+++ b/stellar_sdk/xdr/hello.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .auth_cert import AuthCert
 from .base import Integer, String
 from .hash import Hash
@@ -14,7 +13,6 @@ from .uint256 import Uint256
 __all__ = ["Hello"]
 
 
-@type_checked
 class Hello:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/hmac_sha256_key.py
+++ b/stellar_sdk/xdr/hmac_sha256_key.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["HmacSha256Key"]
 
 
-@type_checked
 class HmacSha256Key:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/hmac_sha256_mac.py
+++ b/stellar_sdk/xdr/hmac_sha256_mac.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["HmacSha256Mac"]
 
 
-@type_checked
 class HmacSha256Mac:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/inflation_payout.py
+++ b/stellar_sdk/xdr/inflation_payout.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .int64 import Int64
 
 __all__ = ["InflationPayout"]
 
 
-@type_checked
 class InflationPayout:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/inflation_result.py
+++ b/stellar_sdk/xdr/inflation_result.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .inflation_payout import InflationPayout
 from .inflation_result_code import InflationResultCode
 
 __all__ = ["InflationResult"]
 
 
-@type_checked
 class InflationResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/inflation_result_code.py
+++ b/stellar_sdk/xdr/inflation_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["InflationResultCode"]
 
 
-@type_checked
 class InflationResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/inner_transaction_result.py
+++ b/stellar_sdk/xdr/inner_transaction_result.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .inner_transaction_result_ext import InnerTransactionResultExt
 from .inner_transaction_result_result import InnerTransactionResultResult
 from .int64 import Int64
@@ -11,7 +10,6 @@ from .int64 import Int64
 __all__ = ["InnerTransactionResult"]
 
 
-@type_checked
 class InnerTransactionResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/inner_transaction_result_ext.py
+++ b/stellar_sdk/xdr/inner_transaction_result_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["InnerTransactionResultExt"]
 
 
-@type_checked
 class InnerTransactionResultExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/inner_transaction_result_pair.py
+++ b/stellar_sdk/xdr/inner_transaction_result_pair.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .hash import Hash
 from .inner_transaction_result import InnerTransactionResult
 
 __all__ = ["InnerTransactionResultPair"]
 
 
-@type_checked
 class InnerTransactionResultPair:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/inner_transaction_result_result.py
+++ b/stellar_sdk/xdr/inner_transaction_result_result.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .operation_result import OperationResult
 from .transaction_result_code import TransactionResultCode
 
 __all__ = ["InnerTransactionResultResult"]
 
 
-@type_checked
 class InnerTransactionResultResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/int32.py
+++ b/stellar_sdk/xdr/int32.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["Int32"]
 
 
-@type_checked
 class Int32:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/int64.py
+++ b/stellar_sdk/xdr/int64.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Hyper
 
 __all__ = ["Int64"]
 
 
-@type_checked
 class Int64:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ip_addr_type.py
+++ b/stellar_sdk/xdr/ip_addr_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["IPAddrType"]
 
 
-@type_checked
 class IPAddrType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_bounds.py
+++ b/stellar_sdk/xdr/ledger_bounds.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .uint32 import Uint32
 
 __all__ = ["LedgerBounds"]
 
 
-@type_checked
 class LedgerBounds:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_close_meta.py
+++ b/stellar_sdk/xdr/ledger_close_meta.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 from .ledger_close_meta_v0 import LedgerCloseMetaV0
 
 __all__ = ["LedgerCloseMeta"]
 
 
-@type_checked
 class LedgerCloseMeta:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_close_meta_v0.py
+++ b/stellar_sdk/xdr/ledger_close_meta_v0.py
@@ -4,7 +4,6 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_header_history_entry import LedgerHeaderHistoryEntry
 from .scp_history_entry import SCPHistoryEntry
 from .transaction_result_meta import TransactionResultMeta
@@ -14,7 +13,6 @@ from .upgrade_entry_meta import UpgradeEntryMeta
 __all__ = ["LedgerCloseMetaV0"]
 
 
-@type_checked
 class LedgerCloseMetaV0:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_close_value_signature.py
+++ b/stellar_sdk/xdr/ledger_close_value_signature.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .node_id import NodeID
 from .signature import Signature
 
 __all__ = ["LedgerCloseValueSignature"]
 
 
-@type_checked
 class LedgerCloseValueSignature:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_entry.py
+++ b/stellar_sdk/xdr/ledger_entry.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_entry_data import LedgerEntryData
 from .ledger_entry_ext import LedgerEntryExt
 from .uint32 import Uint32
@@ -11,7 +10,6 @@ from .uint32 import Uint32
 __all__ = ["LedgerEntry"]
 
 
-@type_checked
 class LedgerEntry:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_entry_change.py
+++ b/stellar_sdk/xdr/ledger_entry_change.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_entry import LedgerEntry
 from .ledger_entry_change_type import LedgerEntryChangeType
 from .ledger_key import LedgerKey
@@ -11,7 +10,6 @@ from .ledger_key import LedgerKey
 __all__ = ["LedgerEntryChange"]
 
 
-@type_checked
 class LedgerEntryChange:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_entry_change_type.py
+++ b/stellar_sdk/xdr/ledger_entry_change_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["LedgerEntryChangeType"]
 
 
-@type_checked
 class LedgerEntryChangeType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_entry_changes.py
+++ b/stellar_sdk/xdr/ledger_entry_changes.py
@@ -4,13 +4,11 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_entry_change import LedgerEntryChange
 
 __all__ = ["LedgerEntryChanges"]
 
 
-@type_checked
 class LedgerEntryChanges:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_entry_data.py
+++ b/stellar_sdk/xdr/ledger_entry_data.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_entry import AccountEntry
 from .claimable_balance_entry import ClaimableBalanceEntry
 from .data_entry import DataEntry
@@ -15,7 +14,6 @@ from .trust_line_entry import TrustLineEntry
 __all__ = ["LedgerEntryData"]
 
 
-@type_checked
 class LedgerEntryData:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_entry_ext.py
+++ b/stellar_sdk/xdr/ledger_entry_ext.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 from .ledger_entry_extension_v1 import LedgerEntryExtensionV1
 
 __all__ = ["LedgerEntryExt"]
 
 
-@type_checked
 class LedgerEntryExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_entry_extension_v1.py
+++ b/stellar_sdk/xdr/ledger_entry_extension_v1.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_entry_extension_v1_ext import LedgerEntryExtensionV1Ext
 from .sponsorship_descriptor import SponsorshipDescriptor
 
 __all__ = ["LedgerEntryExtensionV1"]
 
 
-@type_checked
 class LedgerEntryExtensionV1:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_entry_extension_v1_ext.py
+++ b/stellar_sdk/xdr/ledger_entry_extension_v1_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["LedgerEntryExtensionV1Ext"]
 
 
-@type_checked
 class LedgerEntryExtensionV1Ext:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_entry_type.py
+++ b/stellar_sdk/xdr/ledger_entry_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["LedgerEntryType"]
 
 
-@type_checked
 class LedgerEntryType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_header.py
+++ b/stellar_sdk/xdr/ledger_header.py
@@ -4,7 +4,6 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .hash import Hash
 from .int64 import Int64
 from .ledger_header_ext import LedgerHeaderExt
@@ -15,7 +14,6 @@ from .uint64 import Uint64
 __all__ = ["LedgerHeader"]
 
 
-@type_checked
 class LedgerHeader:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_header_ext.py
+++ b/stellar_sdk/xdr/ledger_header_ext.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 from .ledger_header_extension_v1 import LedgerHeaderExtensionV1
 
 __all__ = ["LedgerHeaderExt"]
 
 
-@type_checked
 class LedgerHeaderExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_header_extension_v1.py
+++ b/stellar_sdk/xdr/ledger_header_extension_v1.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_header_extension_v1_ext import LedgerHeaderExtensionV1Ext
 from .uint32 import Uint32
 
 __all__ = ["LedgerHeaderExtensionV1"]
 
 
-@type_checked
 class LedgerHeaderExtensionV1:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_header_extension_v1_ext.py
+++ b/stellar_sdk/xdr/ledger_header_extension_v1_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["LedgerHeaderExtensionV1Ext"]
 
 
-@type_checked
 class LedgerHeaderExtensionV1Ext:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_header_flags.py
+++ b/stellar_sdk/xdr/ledger_header_flags.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["LedgerHeaderFlags"]
 
 
-@type_checked
 class LedgerHeaderFlags(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_header_history_entry.py
+++ b/stellar_sdk/xdr/ledger_header_history_entry.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .hash import Hash
 from .ledger_header import LedgerHeader
 from .ledger_header_history_entry_ext import LedgerHeaderHistoryEntryExt
@@ -11,7 +10,6 @@ from .ledger_header_history_entry_ext import LedgerHeaderHistoryEntryExt
 __all__ = ["LedgerHeaderHistoryEntry"]
 
 
-@type_checked
 class LedgerHeaderHistoryEntry:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_header_history_entry_ext.py
+++ b/stellar_sdk/xdr/ledger_header_history_entry_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["LedgerHeaderHistoryEntryExt"]
 
 
-@type_checked
 class LedgerHeaderHistoryEntryExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_key.py
+++ b/stellar_sdk/xdr/ledger_key.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_entry_type import LedgerEntryType
 from .ledger_key_account import LedgerKeyAccount
 from .ledger_key_claimable_balance import LedgerKeyClaimableBalance
@@ -15,7 +14,6 @@ from .ledger_key_trust_line import LedgerKeyTrustLine
 __all__ = ["LedgerKey"]
 
 
-@type_checked
 class LedgerKey:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_key_account.py
+++ b/stellar_sdk/xdr/ledger_key_account.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 
 __all__ = ["LedgerKeyAccount"]
 
 
-@type_checked
 class LedgerKeyAccount:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_key_claimable_balance.py
+++ b/stellar_sdk/xdr/ledger_key_claimable_balance.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .claimable_balance_id import ClaimableBalanceID
 
 __all__ = ["LedgerKeyClaimableBalance"]
 
 
-@type_checked
 class LedgerKeyClaimableBalance:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_key_data.py
+++ b/stellar_sdk/xdr/ledger_key_data.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .string64 import String64
 
 __all__ = ["LedgerKeyData"]
 
 
-@type_checked
 class LedgerKeyData:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_key_liquidity_pool.py
+++ b/stellar_sdk/xdr/ledger_key_liquidity_pool.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .pool_id import PoolID
 
 __all__ = ["LedgerKeyLiquidityPool"]
 
 
-@type_checked
 class LedgerKeyLiquidityPool:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_key_offer.py
+++ b/stellar_sdk/xdr/ledger_key_offer.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .int64 import Int64
 
 __all__ = ["LedgerKeyOffer"]
 
 
-@type_checked
 class LedgerKeyOffer:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_key_trust_line.py
+++ b/stellar_sdk/xdr/ledger_key_trust_line.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .trust_line_asset import TrustLineAsset
 
 __all__ = ["LedgerKeyTrustLine"]
 
 
-@type_checked
 class LedgerKeyTrustLine:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_scp_messages.py
+++ b/stellar_sdk/xdr/ledger_scp_messages.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .scp_envelope import SCPEnvelope
 from .uint32 import Uint32
 
 __all__ = ["LedgerSCPMessages"]
 
 
-@type_checked
 class LedgerSCPMessages:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_upgrade.py
+++ b/stellar_sdk/xdr/ledger_upgrade.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_upgrade_type import LedgerUpgradeType
 from .uint32 import Uint32
 
 __all__ = ["LedgerUpgrade"]
 
 
-@type_checked
 class LedgerUpgrade:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/ledger_upgrade_type.py
+++ b/stellar_sdk/xdr/ledger_upgrade_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["LedgerUpgradeType"]
 
 
-@type_checked
 class LedgerUpgradeType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/liabilities.py
+++ b/stellar_sdk/xdr/liabilities.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .int64 import Int64
 
 __all__ = ["Liabilities"]
 
 
-@type_checked
 class Liabilities:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/liquidity_pool_constant_product_parameters.py
+++ b/stellar_sdk/xdr/liquidity_pool_constant_product_parameters.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .int32 import Int32
 
 __all__ = ["LiquidityPoolConstantProductParameters"]
 
 
-@type_checked
 class LiquidityPoolConstantProductParameters:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/liquidity_pool_deposit_op.py
+++ b/stellar_sdk/xdr/liquidity_pool_deposit_op.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .int64 import Int64
 from .pool_id import PoolID
 from .price import Price
@@ -11,7 +10,6 @@ from .price import Price
 __all__ = ["LiquidityPoolDepositOp"]
 
 
-@type_checked
 class LiquidityPoolDepositOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/liquidity_pool_deposit_result.py
+++ b/stellar_sdk/xdr/liquidity_pool_deposit_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .liquidity_pool_deposit_result_code import LiquidityPoolDepositResultCode
 
 __all__ = ["LiquidityPoolDepositResult"]
 
 
-@type_checked
 class LiquidityPoolDepositResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/liquidity_pool_deposit_result_code.py
+++ b/stellar_sdk/xdr/liquidity_pool_deposit_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["LiquidityPoolDepositResultCode"]
 
 
-@type_checked
 class LiquidityPoolDepositResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/liquidity_pool_entry.py
+++ b/stellar_sdk/xdr/liquidity_pool_entry.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .liquidity_pool_entry_body import LiquidityPoolEntryBody
 from .pool_id import PoolID
 
 __all__ = ["LiquidityPoolEntry"]
 
 
-@type_checked
 class LiquidityPoolEntry:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/liquidity_pool_entry_body.py
+++ b/stellar_sdk/xdr/liquidity_pool_entry_body.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .liquidity_pool_entry_constant_product import LiquidityPoolEntryConstantProduct
 from .liquidity_pool_type import LiquidityPoolType
 
 __all__ = ["LiquidityPoolEntryBody"]
 
 
-@type_checked
 class LiquidityPoolEntryBody:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/liquidity_pool_entry_constant_product.py
+++ b/stellar_sdk/xdr/liquidity_pool_entry_constant_product.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .int64 import Int64
 from .liquidity_pool_constant_product_parameters import (
     LiquidityPoolConstantProductParameters,
@@ -12,7 +11,6 @@ from .liquidity_pool_constant_product_parameters import (
 __all__ = ["LiquidityPoolEntryConstantProduct"]
 
 
-@type_checked
 class LiquidityPoolEntryConstantProduct:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/liquidity_pool_parameters.py
+++ b/stellar_sdk/xdr/liquidity_pool_parameters.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .liquidity_pool_constant_product_parameters import (
     LiquidityPoolConstantProductParameters,
 )
@@ -12,7 +11,6 @@ from .liquidity_pool_type import LiquidityPoolType
 __all__ = ["LiquidityPoolParameters"]
 
 
-@type_checked
 class LiquidityPoolParameters:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/liquidity_pool_type.py
+++ b/stellar_sdk/xdr/liquidity_pool_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["LiquidityPoolType"]
 
 
-@type_checked
 class LiquidityPoolType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/liquidity_pool_withdraw_op.py
+++ b/stellar_sdk/xdr/liquidity_pool_withdraw_op.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .int64 import Int64
 from .pool_id import PoolID
 
 __all__ = ["LiquidityPoolWithdrawOp"]
 
 
-@type_checked
 class LiquidityPoolWithdrawOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/liquidity_pool_withdraw_result.py
+++ b/stellar_sdk/xdr/liquidity_pool_withdraw_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .liquidity_pool_withdraw_result_code import LiquidityPoolWithdrawResultCode
 
 __all__ = ["LiquidityPoolWithdrawResult"]
 
 
-@type_checked
 class LiquidityPoolWithdrawResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/liquidity_pool_withdraw_result_code.py
+++ b/stellar_sdk/xdr/liquidity_pool_withdraw_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["LiquidityPoolWithdrawResultCode"]
 
 
-@type_checked
 class LiquidityPoolWithdrawResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/manage_buy_offer_op.py
+++ b/stellar_sdk/xdr/manage_buy_offer_op.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .int64 import Int64
 from .price import Price
@@ -11,7 +10,6 @@ from .price import Price
 __all__ = ["ManageBuyOfferOp"]
 
 
-@type_checked
 class ManageBuyOfferOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/manage_buy_offer_result.py
+++ b/stellar_sdk/xdr/manage_buy_offer_result.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .manage_buy_offer_result_code import ManageBuyOfferResultCode
 from .manage_offer_success_result import ManageOfferSuccessResult
 
 __all__ = ["ManageBuyOfferResult"]
 
 
-@type_checked
 class ManageBuyOfferResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/manage_buy_offer_result_code.py
+++ b/stellar_sdk/xdr/manage_buy_offer_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ManageBuyOfferResultCode"]
 
 
-@type_checked
 class ManageBuyOfferResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/manage_data_op.py
+++ b/stellar_sdk/xdr/manage_data_op.py
@@ -4,14 +4,12 @@ import base64
 from typing import Optional
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .data_value import DataValue
 from .string64 import String64
 
 __all__ = ["ManageDataOp"]
 
 
-@type_checked
 class ManageDataOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/manage_data_result.py
+++ b/stellar_sdk/xdr/manage_data_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .manage_data_result_code import ManageDataResultCode
 
 __all__ = ["ManageDataResult"]
 
 
-@type_checked
 class ManageDataResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/manage_data_result_code.py
+++ b/stellar_sdk/xdr/manage_data_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ManageDataResultCode"]
 
 
-@type_checked
 class ManageDataResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/manage_offer_effect.py
+++ b/stellar_sdk/xdr/manage_offer_effect.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ManageOfferEffect"]
 
 
-@type_checked
 class ManageOfferEffect(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/manage_offer_success_result.py
+++ b/stellar_sdk/xdr/manage_offer_success_result.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .claim_atom import ClaimAtom
 from .manage_offer_success_result_offer import ManageOfferSuccessResultOffer
 
 __all__ = ["ManageOfferSuccessResult"]
 
 
-@type_checked
 class ManageOfferSuccessResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/manage_offer_success_result_offer.py
+++ b/stellar_sdk/xdr/manage_offer_success_result_offer.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .manage_offer_effect import ManageOfferEffect
 from .offer_entry import OfferEntry
 
 __all__ = ["ManageOfferSuccessResultOffer"]
 
 
-@type_checked
 class ManageOfferSuccessResultOffer:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/manage_sell_offer_op.py
+++ b/stellar_sdk/xdr/manage_sell_offer_op.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .int64 import Int64
 from .price import Price
@@ -11,7 +10,6 @@ from .price import Price
 __all__ = ["ManageSellOfferOp"]
 
 
-@type_checked
 class ManageSellOfferOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/manage_sell_offer_result.py
+++ b/stellar_sdk/xdr/manage_sell_offer_result.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .manage_offer_success_result import ManageOfferSuccessResult
 from .manage_sell_offer_result_code import ManageSellOfferResultCode
 
 __all__ = ["ManageSellOfferResult"]
 
 
-@type_checked
 class ManageSellOfferResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/manage_sell_offer_result_code.py
+++ b/stellar_sdk/xdr/manage_sell_offer_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ManageSellOfferResultCode"]
 
 
-@type_checked
 class ManageSellOfferResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/memo.py
+++ b/stellar_sdk/xdr/memo.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import String
 from .hash import Hash
 from .memo_type import MemoType
@@ -12,7 +11,6 @@ from .uint64 import Uint64
 __all__ = ["Memo"]
 
 
-@type_checked
 class Memo:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/memo_type.py
+++ b/stellar_sdk/xdr/memo_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["MemoType"]
 
 
-@type_checked
 class MemoType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/message_type.py
+++ b/stellar_sdk/xdr/message_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["MessageType"]
 
 
-@type_checked
 class MessageType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/muxed_account.py
+++ b/stellar_sdk/xdr/muxed_account.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .crypto_key_type import CryptoKeyType
 from .muxed_account_med25519 import MuxedAccountMed25519
 from .uint256 import Uint256
@@ -11,7 +10,6 @@ from .uint256 import Uint256
 __all__ = ["MuxedAccount"]
 
 
-@type_checked
 class MuxedAccount:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/muxed_account_med25519.py
+++ b/stellar_sdk/xdr/muxed_account_med25519.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .uint64 import Uint64
 from .uint256 import Uint256
 
 __all__ = ["MuxedAccountMed25519"]
 
 
-@type_checked
 class MuxedAccountMed25519:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/node_id.py
+++ b/stellar_sdk/xdr/node_id.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .public_key import PublicKey
 
 __all__ = ["NodeID"]
 
 
-@type_checked
 class NodeID:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/offer_entry.py
+++ b/stellar_sdk/xdr/offer_entry.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .asset import Asset
 from .int64 import Int64
@@ -14,7 +13,6 @@ from .uint32 import Uint32
 __all__ = ["OfferEntry"]
 
 
-@type_checked
 class OfferEntry:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/offer_entry_ext.py
+++ b/stellar_sdk/xdr/offer_entry_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["OfferEntryExt"]
 
 
-@type_checked
 class OfferEntryExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/offer_entry_flags.py
+++ b/stellar_sdk/xdr/offer_entry_flags.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["OfferEntryFlags"]
 
 
-@type_checked
 class OfferEntryFlags(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/operation.py
+++ b/stellar_sdk/xdr/operation.py
@@ -4,14 +4,12 @@ import base64
 from typing import Optional
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .muxed_account import MuxedAccount
 from .operation_body import OperationBody
 
 __all__ = ["Operation"]
 
 
-@type_checked
 class Operation:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/operation_body.py
+++ b/stellar_sdk/xdr/operation_body.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .allow_trust_op import AllowTrustOp
 from .begin_sponsoring_future_reserves_op import BeginSponsoringFutureReservesOp
 from .bump_sequence_op import BumpSequenceOp
@@ -31,7 +30,6 @@ from .set_trust_line_flags_op import SetTrustLineFlagsOp
 __all__ = ["OperationBody"]
 
 
-@type_checked
 class OperationBody:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/operation_meta.py
+++ b/stellar_sdk/xdr/operation_meta.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_entry_changes import LedgerEntryChanges
 
 __all__ = ["OperationMeta"]
 
 
-@type_checked
 class OperationMeta:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/operation_result.py
+++ b/stellar_sdk/xdr/operation_result.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .operation_result_code import OperationResultCode
 from .operation_result_tr import OperationResultTr
 
 __all__ = ["OperationResult"]
 
 
-@type_checked
 class OperationResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/operation_result_code.py
+++ b/stellar_sdk/xdr/operation_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["OperationResultCode"]
 
 
-@type_checked
 class OperationResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/operation_result_tr.py
+++ b/stellar_sdk/xdr/operation_result_tr.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_merge_result import AccountMergeResult
 from .allow_trust_result import AllowTrustResult
 from .begin_sponsoring_future_reserves_result import BeginSponsoringFutureReservesResult
@@ -32,7 +31,6 @@ from .set_trust_line_flags_result import SetTrustLineFlagsResult
 __all__ = ["OperationResultTr"]
 
 
-@type_checked
 class OperationResultTr:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/operation_type.py
+++ b/stellar_sdk/xdr/operation_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["OperationType"]
 
 
-@type_checked
 class OperationType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/path_payment_strict_receive_op.py
+++ b/stellar_sdk/xdr/path_payment_strict_receive_op.py
@@ -4,7 +4,6 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .int64 import Int64
 from .muxed_account import MuxedAccount
@@ -12,7 +11,6 @@ from .muxed_account import MuxedAccount
 __all__ = ["PathPaymentStrictReceiveOp"]
 
 
-@type_checked
 class PathPaymentStrictReceiveOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/path_payment_strict_receive_result.py
+++ b/stellar_sdk/xdr/path_payment_strict_receive_result.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .path_payment_strict_receive_result_code import PathPaymentStrictReceiveResultCode
 from .path_payment_strict_receive_result_success import (
@@ -13,7 +12,6 @@ from .path_payment_strict_receive_result_success import (
 __all__ = ["PathPaymentStrictReceiveResult"]
 
 
-@type_checked
 class PathPaymentStrictReceiveResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/path_payment_strict_receive_result_code.py
+++ b/stellar_sdk/xdr/path_payment_strict_receive_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["PathPaymentStrictReceiveResultCode"]
 
 
-@type_checked
 class PathPaymentStrictReceiveResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/path_payment_strict_receive_result_success.py
+++ b/stellar_sdk/xdr/path_payment_strict_receive_result_success.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .claim_atom import ClaimAtom
 from .simple_payment_result import SimplePaymentResult
 
 __all__ = ["PathPaymentStrictReceiveResultSuccess"]
 
 
-@type_checked
 class PathPaymentStrictReceiveResultSuccess:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/path_payment_strict_send_op.py
+++ b/stellar_sdk/xdr/path_payment_strict_send_op.py
@@ -4,7 +4,6 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .int64 import Int64
 from .muxed_account import MuxedAccount
@@ -12,7 +11,6 @@ from .muxed_account import MuxedAccount
 __all__ = ["PathPaymentStrictSendOp"]
 
 
-@type_checked
 class PathPaymentStrictSendOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/path_payment_strict_send_result.py
+++ b/stellar_sdk/xdr/path_payment_strict_send_result.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .path_payment_strict_send_result_code import PathPaymentStrictSendResultCode
 from .path_payment_strict_send_result_success import PathPaymentStrictSendResultSuccess
@@ -11,7 +10,6 @@ from .path_payment_strict_send_result_success import PathPaymentStrictSendResult
 __all__ = ["PathPaymentStrictSendResult"]
 
 
-@type_checked
 class PathPaymentStrictSendResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/path_payment_strict_send_result_code.py
+++ b/stellar_sdk/xdr/path_payment_strict_send_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["PathPaymentStrictSendResultCode"]
 
 
-@type_checked
 class PathPaymentStrictSendResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/path_payment_strict_send_result_success.py
+++ b/stellar_sdk/xdr/path_payment_strict_send_result_success.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .claim_atom import ClaimAtom
 from .simple_payment_result import SimplePaymentResult
 
 __all__ = ["PathPaymentStrictSendResultSuccess"]
 
 
-@type_checked
 class PathPaymentStrictSendResultSuccess:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/payment_op.py
+++ b/stellar_sdk/xdr/payment_op.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .asset import Asset
 from .int64 import Int64
 from .muxed_account import MuxedAccount
@@ -11,7 +10,6 @@ from .muxed_account import MuxedAccount
 __all__ = ["PaymentOp"]
 
 
-@type_checked
 class PaymentOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/payment_result.py
+++ b/stellar_sdk/xdr/payment_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .payment_result_code import PaymentResultCode
 
 __all__ = ["PaymentResult"]
 
 
-@type_checked
 class PaymentResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/payment_result_code.py
+++ b/stellar_sdk/xdr/payment_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["PaymentResultCode"]
 
 
-@type_checked
 class PaymentResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/peer_address.py
+++ b/stellar_sdk/xdr/peer_address.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .peer_address_ip import PeerAddressIp
 from .uint32 import Uint32
 
 __all__ = ["PeerAddress"]
 
 
-@type_checked
 class PeerAddress:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/peer_address_ip.py
+++ b/stellar_sdk/xdr/peer_address_ip.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 from .ip_addr_type import IPAddrType
 
 __all__ = ["PeerAddressIp"]
 
 
-@type_checked
 class PeerAddressIp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/peer_stat_list.py
+++ b/stellar_sdk/xdr/peer_stat_list.py
@@ -4,13 +4,11 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .peer_stats import PeerStats
 
 __all__ = ["PeerStatList"]
 
 
-@type_checked
 class PeerStatList:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/peer_stats.py
+++ b/stellar_sdk/xdr/peer_stats.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import String
 from .node_id import NodeID
 from .uint64 import Uint64
@@ -11,7 +10,6 @@ from .uint64 import Uint64
 __all__ = ["PeerStats"]
 
 
-@type_checked
 class PeerStats:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/pool_id.py
+++ b/stellar_sdk/xdr/pool_id.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .hash import Hash
 
 __all__ = ["PoolID"]
 
 
-@type_checked
 class PoolID:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/precondition_type.py
+++ b/stellar_sdk/xdr/precondition_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["PreconditionType"]
 
 
-@type_checked
 class PreconditionType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/preconditions.py
+++ b/stellar_sdk/xdr/preconditions.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .precondition_type import PreconditionType
 from .preconditions_v2 import PreconditionsV2
 from .time_bounds import TimeBounds
@@ -11,7 +10,6 @@ from .time_bounds import TimeBounds
 __all__ = ["Preconditions"]
 
 
-@type_checked
 class Preconditions:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/preconditions_v2.py
+++ b/stellar_sdk/xdr/preconditions_v2.py
@@ -4,7 +4,6 @@ import base64
 from typing import List, Optional
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .duration import Duration
 from .ledger_bounds import LedgerBounds
 from .sequence_number import SequenceNumber
@@ -15,7 +14,6 @@ from .uint32 import Uint32
 __all__ = ["PreconditionsV2"]
 
 
-@type_checked
 class PreconditionsV2:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/price.py
+++ b/stellar_sdk/xdr/price.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .int32 import Int32
 
 __all__ = ["Price"]
 
 
-@type_checked
 class Price:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/public_key.py
+++ b/stellar_sdk/xdr/public_key.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .public_key_type import PublicKeyType
 from .uint256 import Uint256
 
 __all__ = ["PublicKey"]
 
 
-@type_checked
 class PublicKey:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/public_key_type.py
+++ b/stellar_sdk/xdr/public_key_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["PublicKeyType"]
 
 
-@type_checked
 class PublicKeyType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/revoke_sponsorship_op.py
+++ b/stellar_sdk/xdr/revoke_sponsorship_op.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_key import LedgerKey
 from .revoke_sponsorship_op_signer import RevokeSponsorshipOpSigner
 from .revoke_sponsorship_type import RevokeSponsorshipType
@@ -11,7 +10,6 @@ from .revoke_sponsorship_type import RevokeSponsorshipType
 __all__ = ["RevokeSponsorshipOp"]
 
 
-@type_checked
 class RevokeSponsorshipOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/revoke_sponsorship_op_signer.py
+++ b/stellar_sdk/xdr/revoke_sponsorship_op_signer.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .signer_key import SignerKey
 
 __all__ = ["RevokeSponsorshipOpSigner"]
 
 
-@type_checked
 class RevokeSponsorshipOpSigner:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/revoke_sponsorship_result.py
+++ b/stellar_sdk/xdr/revoke_sponsorship_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .revoke_sponsorship_result_code import RevokeSponsorshipResultCode
 
 __all__ = ["RevokeSponsorshipResult"]
 
 
-@type_checked
 class RevokeSponsorshipResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/revoke_sponsorship_result_code.py
+++ b/stellar_sdk/xdr/revoke_sponsorship_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["RevokeSponsorshipResultCode"]
 
 
-@type_checked
 class RevokeSponsorshipResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/revoke_sponsorship_type.py
+++ b/stellar_sdk/xdr/revoke_sponsorship_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["RevokeSponsorshipType"]
 
 
-@type_checked
 class RevokeSponsorshipType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/scp_ballot.py
+++ b/stellar_sdk/xdr/scp_ballot.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .uint32 import Uint32
 from .value import Value
 
 __all__ = ["SCPBallot"]
 
 
-@type_checked
 class SCPBallot:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/scp_envelope.py
+++ b/stellar_sdk/xdr/scp_envelope.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .scp_statement import SCPStatement
 from .signature import Signature
 
 __all__ = ["SCPEnvelope"]
 
 
-@type_checked
 class SCPEnvelope:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/scp_history_entry.py
+++ b/stellar_sdk/xdr/scp_history_entry.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 from .scp_history_entry_v0 import SCPHistoryEntryV0
 
 __all__ = ["SCPHistoryEntry"]
 
 
-@type_checked
 class SCPHistoryEntry:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/scp_history_entry_v0.py
+++ b/stellar_sdk/xdr/scp_history_entry_v0.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_scp_messages import LedgerSCPMessages
 from .scp_quorum_set import SCPQuorumSet
 
 __all__ = ["SCPHistoryEntryV0"]
 
 
-@type_checked
 class SCPHistoryEntryV0:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/scp_nomination.py
+++ b/stellar_sdk/xdr/scp_nomination.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .hash import Hash
 from .value import Value
 
 __all__ = ["SCPNomination"]
 
 
-@type_checked
 class SCPNomination:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/scp_quorum_set.py
+++ b/stellar_sdk/xdr/scp_quorum_set.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .node_id import NodeID
 from .uint32 import Uint32
 
 __all__ = ["SCPQuorumSet"]
 
 
-@type_checked
 class SCPQuorumSet:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/scp_statement.py
+++ b/stellar_sdk/xdr/scp_statement.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .node_id import NodeID
 from .scp_statement_pledges import SCPStatementPledges
 from .uint64 import Uint64
@@ -11,7 +10,6 @@ from .uint64 import Uint64
 __all__ = ["SCPStatement"]
 
 
-@type_checked
 class SCPStatement:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/scp_statement_confirm.py
+++ b/stellar_sdk/xdr/scp_statement_confirm.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .hash import Hash
 from .scp_ballot import SCPBallot
 from .uint32 import Uint32
@@ -11,7 +10,6 @@ from .uint32 import Uint32
 __all__ = ["SCPStatementConfirm"]
 
 
-@type_checked
 class SCPStatementConfirm:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/scp_statement_externalize.py
+++ b/stellar_sdk/xdr/scp_statement_externalize.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .hash import Hash
 from .scp_ballot import SCPBallot
 from .uint32 import Uint32
@@ -11,7 +10,6 @@ from .uint32 import Uint32
 __all__ = ["SCPStatementExternalize"]
 
 
-@type_checked
 class SCPStatementExternalize:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/scp_statement_pledges.py
+++ b/stellar_sdk/xdr/scp_statement_pledges.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .scp_nomination import SCPNomination
 from .scp_statement_confirm import SCPStatementConfirm
 from .scp_statement_externalize import SCPStatementExternalize
@@ -13,7 +12,6 @@ from .scp_statement_type import SCPStatementType
 __all__ = ["SCPStatementPledges"]
 
 
-@type_checked
 class SCPStatementPledges:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/scp_statement_prepare.py
+++ b/stellar_sdk/xdr/scp_statement_prepare.py
@@ -4,7 +4,6 @@ import base64
 from typing import Optional
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .hash import Hash
 from .scp_ballot import SCPBallot
 from .uint32 import Uint32
@@ -12,7 +11,6 @@ from .uint32 import Uint32
 __all__ = ["SCPStatementPrepare"]
 
 
-@type_checked
 class SCPStatementPrepare:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/scp_statement_type.py
+++ b/stellar_sdk/xdr/scp_statement_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["SCPStatementType"]
 
 
-@type_checked
 class SCPStatementType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/send_more.py
+++ b/stellar_sdk/xdr/send_more.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .uint32 import Uint32
 
 __all__ = ["SendMore"]
 
 
-@type_checked
 class SendMore:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/sequence_number.py
+++ b/stellar_sdk/xdr/sequence_number.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .int64 import Int64
 
 __all__ = ["SequenceNumber"]
 
 
-@type_checked
 class SequenceNumber:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/set_options_op.py
+++ b/stellar_sdk/xdr/set_options_op.py
@@ -4,7 +4,6 @@ import base64
 from typing import Optional
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .signer import Signer
 from .string32 import String32
@@ -13,7 +12,6 @@ from .uint32 import Uint32
 __all__ = ["SetOptionsOp"]
 
 
-@type_checked
 class SetOptionsOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/set_options_result.py
+++ b/stellar_sdk/xdr/set_options_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .set_options_result_code import SetOptionsResultCode
 
 __all__ = ["SetOptionsResult"]
 
 
-@type_checked
 class SetOptionsResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/set_options_result_code.py
+++ b/stellar_sdk/xdr/set_options_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["SetOptionsResultCode"]
 
 
-@type_checked
 class SetOptionsResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/set_trust_line_flags_op.py
+++ b/stellar_sdk/xdr/set_trust_line_flags_op.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .asset import Asset
 from .uint32 import Uint32
@@ -11,7 +10,6 @@ from .uint32 import Uint32
 __all__ = ["SetTrustLineFlagsOp"]
 
 
-@type_checked
 class SetTrustLineFlagsOp:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/set_trust_line_flags_result.py
+++ b/stellar_sdk/xdr/set_trust_line_flags_result.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .set_trust_line_flags_result_code import SetTrustLineFlagsResultCode
 
 __all__ = ["SetTrustLineFlagsResult"]
 
 
-@type_checked
 class SetTrustLineFlagsResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/set_trust_line_flags_result_code.py
+++ b/stellar_sdk/xdr/set_trust_line_flags_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["SetTrustLineFlagsResultCode"]
 
 
-@type_checked
 class SetTrustLineFlagsResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/signature.py
+++ b/stellar_sdk/xdr/signature.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["Signature"]
 
 
-@type_checked
 class Signature:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/signature_hint.py
+++ b/stellar_sdk/xdr/signature_hint.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["SignatureHint"]
 
 
-@type_checked
 class SignatureHint:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/signed_survey_request_message.py
+++ b/stellar_sdk/xdr/signed_survey_request_message.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .signature import Signature
 from .survey_request_message import SurveyRequestMessage
 
 __all__ = ["SignedSurveyRequestMessage"]
 
 
-@type_checked
 class SignedSurveyRequestMessage:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/signed_survey_response_message.py
+++ b/stellar_sdk/xdr/signed_survey_response_message.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .signature import Signature
 from .survey_response_message import SurveyResponseMessage
 
 __all__ = ["SignedSurveyResponseMessage"]
 
 
-@type_checked
 class SignedSurveyResponseMessage:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/signer.py
+++ b/stellar_sdk/xdr/signer.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .signer_key import SignerKey
 from .uint32 import Uint32
 
 __all__ = ["Signer"]
 
 
-@type_checked
 class Signer:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/signer_key.py
+++ b/stellar_sdk/xdr/signer_key.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .signer_key_ed25519_signed_payload import SignerKeyEd25519SignedPayload
 from .signer_key_type import SignerKeyType
 from .uint256 import Uint256
@@ -11,7 +10,6 @@ from .uint256 import Uint256
 __all__ = ["SignerKey"]
 
 
-@type_checked
 class SignerKey:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/signer_key_ed25519_signed_payload.py
+++ b/stellar_sdk/xdr/signer_key_ed25519_signed_payload.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 from .uint256 import Uint256
 
 __all__ = ["SignerKeyEd25519SignedPayload"]
 
 
-@type_checked
 class SignerKeyEd25519SignedPayload:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/signer_key_type.py
+++ b/stellar_sdk/xdr/signer_key_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["SignerKeyType"]
 
 
-@type_checked
 class SignerKeyType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/simple_payment_result.py
+++ b/stellar_sdk/xdr/simple_payment_result.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .asset import Asset
 from .int64 import Int64
@@ -11,7 +10,6 @@ from .int64 import Int64
 __all__ = ["SimplePaymentResult"]
 
 
-@type_checked
 class SimplePaymentResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/sponsorship_descriptor.py
+++ b/stellar_sdk/xdr/sponsorship_descriptor.py
@@ -4,13 +4,11 @@ import base64
 from typing import Optional
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 
 __all__ = ["SponsorshipDescriptor"]
 
 
-@type_checked
 class SponsorshipDescriptor:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/stellar_message.py
+++ b/stellar_sdk/xdr/stellar_message.py
@@ -4,7 +4,6 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .auth import Auth
 from .dont_have import DontHave
 from .error import Error
@@ -24,7 +23,6 @@ from .uint256 import Uint256
 __all__ = ["StellarMessage"]
 
 
-@type_checked
 class StellarMessage:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/stellar_value.py
+++ b/stellar_sdk/xdr/stellar_value.py
@@ -4,7 +4,6 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .hash import Hash
 from .stellar_value_ext import StellarValueExt
 from .time_point import TimePoint
@@ -13,7 +12,6 @@ from .upgrade_type import UpgradeType
 __all__ = ["StellarValue"]
 
 
-@type_checked
 class StellarValue:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/stellar_value_ext.py
+++ b/stellar_sdk/xdr/stellar_value_ext.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_close_value_signature import LedgerCloseValueSignature
 from .stellar_value_type import StellarValueType
 
 __all__ = ["StellarValueExt"]
 
 
-@type_checked
 class StellarValueExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/stellar_value_type.py
+++ b/stellar_sdk/xdr/stellar_value_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["StellarValueType"]
 
 
-@type_checked
 class StellarValueType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/string32.py
+++ b/stellar_sdk/xdr/string32.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import String
 
 __all__ = ["String32"]
 
 
-@type_checked
 class String32:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/string64.py
+++ b/stellar_sdk/xdr/string64.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import String
 
 __all__ = ["String64"]
 
 
-@type_checked
 class String64:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/survey_message_command_type.py
+++ b/stellar_sdk/xdr/survey_message_command_type.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["SurveyMessageCommandType"]
 
 
-@type_checked
 class SurveyMessageCommandType(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/survey_request_message.py
+++ b/stellar_sdk/xdr/survey_request_message.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .curve25519_public import Curve25519Public
 from .node_id import NodeID
 from .survey_message_command_type import SurveyMessageCommandType
@@ -12,7 +11,6 @@ from .uint32 import Uint32
 __all__ = ["SurveyRequestMessage"]
 
 
-@type_checked
 class SurveyRequestMessage:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/survey_response_body.py
+++ b/stellar_sdk/xdr/survey_response_body.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .survey_message_command_type import SurveyMessageCommandType
 from .topology_response_body import TopologyResponseBody
 
 __all__ = ["SurveyResponseBody"]
 
 
-@type_checked
 class SurveyResponseBody:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/survey_response_message.py
+++ b/stellar_sdk/xdr/survey_response_message.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .encrypted_body import EncryptedBody
 from .node_id import NodeID
 from .survey_message_command_type import SurveyMessageCommandType
@@ -12,7 +11,6 @@ from .uint32 import Uint32
 __all__ = ["SurveyResponseMessage"]
 
 
-@type_checked
 class SurveyResponseMessage:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/threshold_indexes.py
+++ b/stellar_sdk/xdr/threshold_indexes.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["ThresholdIndexes"]
 
 
-@type_checked
 class ThresholdIndexes(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/thresholds.py
+++ b/stellar_sdk/xdr/thresholds.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["Thresholds"]
 
 
-@type_checked
 class Thresholds:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/time_bounds.py
+++ b/stellar_sdk/xdr/time_bounds.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .time_point import TimePoint
 
 __all__ = ["TimeBounds"]
 
 
-@type_checked
 class TimeBounds:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/time_point.py
+++ b/stellar_sdk/xdr/time_point.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .uint64 import Uint64
 
 __all__ = ["TimePoint"]
 
 
-@type_checked
 class TimePoint:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/topology_response_body.py
+++ b/stellar_sdk/xdr/topology_response_body.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .peer_stat_list import PeerStatList
 from .uint32 import Uint32
 
 __all__ = ["TopologyResponseBody"]
 
 
-@type_checked
 class TopologyResponseBody:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction.py
+++ b/stellar_sdk/xdr/transaction.py
@@ -4,7 +4,6 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .constants import *
 from .memo import Memo
 from .muxed_account import MuxedAccount
@@ -17,7 +16,6 @@ from .uint32 import Uint32
 __all__ = ["Transaction"]
 
 
-@type_checked
 class Transaction:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_envelope.py
+++ b/stellar_sdk/xdr/transaction_envelope.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .envelope_type import EnvelopeType
 from .fee_bump_transaction_envelope import FeeBumpTransactionEnvelope
 from .transaction_v0_envelope import TransactionV0Envelope
@@ -12,7 +11,6 @@ from .transaction_v1_envelope import TransactionV1Envelope
 __all__ = ["TransactionEnvelope"]
 
 
-@type_checked
 class TransactionEnvelope:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_ext.py
+++ b/stellar_sdk/xdr/transaction_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["TransactionExt"]
 
 
-@type_checked
 class TransactionExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_history_entry.py
+++ b/stellar_sdk/xdr/transaction_history_entry.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .transaction_history_entry_ext import TransactionHistoryEntryExt
 from .transaction_set import TransactionSet
 from .uint32 import Uint32
@@ -11,7 +10,6 @@ from .uint32 import Uint32
 __all__ = ["TransactionHistoryEntry"]
 
 
-@type_checked
 class TransactionHistoryEntry:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_history_entry_ext.py
+++ b/stellar_sdk/xdr/transaction_history_entry_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["TransactionHistoryEntryExt"]
 
 
-@type_checked
 class TransactionHistoryEntryExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_history_result_entry.py
+++ b/stellar_sdk/xdr/transaction_history_result_entry.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .transaction_history_result_entry_ext import TransactionHistoryResultEntryExt
 from .transaction_result_set import TransactionResultSet
 from .uint32 import Uint32
@@ -11,7 +10,6 @@ from .uint32 import Uint32
 __all__ = ["TransactionHistoryResultEntry"]
 
 
-@type_checked
 class TransactionHistoryResultEntry:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_history_result_entry_ext.py
+++ b/stellar_sdk/xdr/transaction_history_result_entry_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["TransactionHistoryResultEntryExt"]
 
 
-@type_checked
 class TransactionHistoryResultEntryExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_meta.py
+++ b/stellar_sdk/xdr/transaction_meta.py
@@ -4,7 +4,6 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 from .operation_meta import OperationMeta
 from .transaction_meta_v1 import TransactionMetaV1
@@ -13,7 +12,6 @@ from .transaction_meta_v2 import TransactionMetaV2
 __all__ = ["TransactionMeta"]
 
 
-@type_checked
 class TransactionMeta:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_meta_v1.py
+++ b/stellar_sdk/xdr/transaction_meta_v1.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_entry_changes import LedgerEntryChanges
 from .operation_meta import OperationMeta
 
 __all__ = ["TransactionMetaV1"]
 
 
-@type_checked
 class TransactionMetaV1:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_meta_v2.py
+++ b/stellar_sdk/xdr/transaction_meta_v2.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_entry_changes import LedgerEntryChanges
 from .operation_meta import OperationMeta
 
 __all__ = ["TransactionMetaV2"]
 
 
-@type_checked
 class TransactionMetaV2:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_result.py
+++ b/stellar_sdk/xdr/transaction_result.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .int64 import Int64
 from .transaction_result_ext import TransactionResultExt
 from .transaction_result_result import TransactionResultResult
@@ -11,7 +10,6 @@ from .transaction_result_result import TransactionResultResult
 __all__ = ["TransactionResult"]
 
 
-@type_checked
 class TransactionResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_result_code.py
+++ b/stellar_sdk/xdr/transaction_result_code.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["TransactionResultCode"]
 
 
-@type_checked
 class TransactionResultCode(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_result_ext.py
+++ b/stellar_sdk/xdr/transaction_result_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["TransactionResultExt"]
 
 
-@type_checked
 class TransactionResultExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_result_meta.py
+++ b/stellar_sdk/xdr/transaction_result_meta.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_entry_changes import LedgerEntryChanges
 from .transaction_meta import TransactionMeta
 from .transaction_result_pair import TransactionResultPair
@@ -11,7 +10,6 @@ from .transaction_result_pair import TransactionResultPair
 __all__ = ["TransactionResultMeta"]
 
 
-@type_checked
 class TransactionResultMeta:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_result_pair.py
+++ b/stellar_sdk/xdr/transaction_result_pair.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .hash import Hash
 from .transaction_result import TransactionResult
 
 __all__ = ["TransactionResultPair"]
 
 
-@type_checked
 class TransactionResultPair:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_result_result.py
+++ b/stellar_sdk/xdr/transaction_result_result.py
@@ -4,7 +4,6 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .inner_transaction_result_pair import InnerTransactionResultPair
 from .operation_result import OperationResult
 from .transaction_result_code import TransactionResultCode
@@ -12,7 +11,6 @@ from .transaction_result_code import TransactionResultCode
 __all__ = ["TransactionResultResult"]
 
 
-@type_checked
 class TransactionResultResult:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_result_set.py
+++ b/stellar_sdk/xdr/transaction_result_set.py
@@ -4,13 +4,11 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .transaction_result_pair import TransactionResultPair
 
 __all__ = ["TransactionResultSet"]
 
 
-@type_checked
 class TransactionResultSet:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_set.py
+++ b/stellar_sdk/xdr/transaction_set.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .hash import Hash
 from .transaction_envelope import TransactionEnvelope
 
 __all__ = ["TransactionSet"]
 
 
-@type_checked
 class TransactionSet:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_signature_payload.py
+++ b/stellar_sdk/xdr/transaction_signature_payload.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .hash import Hash
 from .transaction_signature_payload_tagged_transaction import (
     TransactionSignaturePayloadTaggedTransaction,
@@ -12,7 +11,6 @@ from .transaction_signature_payload_tagged_transaction import (
 __all__ = ["TransactionSignaturePayload"]
 
 
-@type_checked
 class TransactionSignaturePayload:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_signature_payload_tagged_transaction.py
+++ b/stellar_sdk/xdr/transaction_signature_payload_tagged_transaction.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .envelope_type import EnvelopeType
 from .fee_bump_transaction import FeeBumpTransaction
 from .transaction import Transaction
@@ -11,7 +10,6 @@ from .transaction import Transaction
 __all__ = ["TransactionSignaturePayloadTaggedTransaction"]
 
 
-@type_checked
 class TransactionSignaturePayloadTaggedTransaction:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_v0.py
+++ b/stellar_sdk/xdr/transaction_v0.py
@@ -4,7 +4,6 @@ import base64
 from typing import List, Optional
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .constants import *
 from .memo import Memo
 from .operation import Operation
@@ -17,7 +16,6 @@ from .uint256 import Uint256
 __all__ = ["TransactionV0"]
 
 
-@type_checked
 class TransactionV0:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_v0_envelope.py
+++ b/stellar_sdk/xdr/transaction_v0_envelope.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .decorated_signature import DecoratedSignature
 from .transaction_v0 import TransactionV0
 
 __all__ = ["TransactionV0Envelope"]
 
 
-@type_checked
 class TransactionV0Envelope:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_v0_ext.py
+++ b/stellar_sdk/xdr/transaction_v0_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["TransactionV0Ext"]
 
 
-@type_checked
 class TransactionV0Ext:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/transaction_v1_envelope.py
+++ b/stellar_sdk/xdr/transaction_v1_envelope.py
@@ -4,14 +4,12 @@ import base64
 from typing import List
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .decorated_signature import DecoratedSignature
 from .transaction import Transaction
 
 __all__ = ["TransactionV1Envelope"]
 
 
-@type_checked
 class TransactionV1Envelope:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/trust_line_asset.py
+++ b/stellar_sdk/xdr/trust_line_asset.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .alpha_num4 import AlphaNum4
 from .alpha_num12 import AlphaNum12
 from .asset_type import AssetType
@@ -12,7 +11,6 @@ from .pool_id import PoolID
 __all__ = ["TrustLineAsset"]
 
 
-@type_checked
 class TrustLineAsset:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/trust_line_entry.py
+++ b/stellar_sdk/xdr/trust_line_entry.py
@@ -3,7 +3,6 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .account_id import AccountID
 from .int64 import Int64
 from .trust_line_asset import TrustLineAsset
@@ -13,7 +12,6 @@ from .uint32 import Uint32
 __all__ = ["TrustLineEntry"]
 
 
-@type_checked
 class TrustLineEntry:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/trust_line_entry_ext.py
+++ b/stellar_sdk/xdr/trust_line_entry_ext.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 from .trust_line_entry_v1 import TrustLineEntryV1
 
 __all__ = ["TrustLineEntryExt"]
 
 
-@type_checked
 class TrustLineEntryExt:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/trust_line_entry_extension_v2.py
+++ b/stellar_sdk/xdr/trust_line_entry_extension_v2.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .int32 import Int32
 from .trust_line_entry_extension_v2_ext import TrustLineEntryExtensionV2Ext
 
 __all__ = ["TrustLineEntryExtensionV2"]
 
 
-@type_checked
 class TrustLineEntryExtensionV2:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/trust_line_entry_extension_v2_ext.py
+++ b/stellar_sdk/xdr/trust_line_entry_extension_v2_ext.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 
 __all__ = ["TrustLineEntryExtensionV2Ext"]
 
 
-@type_checked
 class TrustLineEntryExtensionV2Ext:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/trust_line_entry_v1.py
+++ b/stellar_sdk/xdr/trust_line_entry_v1.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .liabilities import Liabilities
 from .trust_line_entry_v1_ext import TrustLineEntryV1Ext
 
 __all__ = ["TrustLineEntryV1"]
 
 
-@type_checked
 class TrustLineEntryV1:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/trust_line_entry_v1_ext.py
+++ b/stellar_sdk/xdr/trust_line_entry_v1_ext.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Integer
 from .trust_line_entry_extension_v2 import TrustLineEntryExtensionV2
 
 __all__ = ["TrustLineEntryV1Ext"]
 
 
-@type_checked
 class TrustLineEntryV1Ext:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/trust_line_flags.py
+++ b/stellar_sdk/xdr/trust_line_flags.py
@@ -5,12 +5,10 @@ from enum import IntEnum
 from xdrlib import Packer, Unpacker
 
 from ..__version__ import __issues__
-from ..type_checked import type_checked
 
 __all__ = ["TrustLineFlags"]
 
 
-@type_checked
 class TrustLineFlags(IntEnum):
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/uint256.py
+++ b/stellar_sdk/xdr/uint256.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["Uint256"]
 
 
-@type_checked
 class Uint256:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/uint32.py
+++ b/stellar_sdk/xdr/uint32.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import UnsignedInteger
 
 __all__ = ["Uint32"]
 
 
-@type_checked
 class Uint32:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/uint64.py
+++ b/stellar_sdk/xdr/uint64.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import UnsignedHyper
 
 __all__ = ["Uint64"]
 
 
-@type_checked
 class Uint64:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/upgrade_entry_meta.py
+++ b/stellar_sdk/xdr/upgrade_entry_meta.py
@@ -3,14 +3,12 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .ledger_entry_changes import LedgerEntryChanges
 from .ledger_upgrade import LedgerUpgrade
 
 __all__ = ["UpgradeEntryMeta"]
 
 
-@type_checked
 class UpgradeEntryMeta:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/upgrade_type.py
+++ b/stellar_sdk/xdr/upgrade_type.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["UpgradeType"]
 
 
-@type_checked
 class UpgradeType:
     """
     XDR Source Code::

--- a/stellar_sdk/xdr/utils.py
+++ b/stellar_sdk/xdr/utils.py
@@ -1,12 +1,9 @@
 from decimal import Context, Decimal, Inexact
 from typing import Union
 
-from ..type_checked import type_checked
-
 _ONE = Decimal(10 ** 7)
 
 
-@type_checked
 def to_xdr_amount(value: Union[str, Decimal]) -> int:
     """Converts an amount to the appropriate value to send over the network
     as a part of an XDR object.
@@ -49,7 +46,6 @@ def to_xdr_amount(value: Union[str, Decimal]) -> int:
     return amount
 
 
-@type_checked
 def from_xdr_amount(value: int) -> str:
     """Converts an str amount from an XDR amount object
 

--- a/stellar_sdk/xdr/value.py
+++ b/stellar_sdk/xdr/value.py
@@ -3,13 +3,11 @@
 import base64
 from xdrlib import Packer, Unpacker
 
-from ..type_checked import type_checked
 from .base import Opaque
 
 __all__ = ["Value"]
 
 
-@type_checked
 class Value:
     """
     XDR Source Code::


### PR DESCRIPTION
Runtime type checking can cost a lot of performance, although you can avoid it by enabling `-O`, but I don't think users will use `stellar_sdk.xdr` directly, if they use it, the user needs to be responsible for checking all this.