### PR TITLE
refator: no longer sets "now" as the default cursor for AiohttpClient.stream

### DIFF
--- a/stellar_sdk/client/aiohttp_client.py
+++ b/stellar_sdk/client/aiohttp_client.py
@@ -172,9 +172,6 @@ class AiohttpClient(BaseAsyncClient):
 
         query_params = {**params} if params else dict()
 
-        if query_params.get("cursor") is None:
-            query_params["cursor"] = "now"  # Start monitoring from now.
-
         query_params.update(**IDENTIFICATION_HEADERS)
         retry = 0.1
 


### PR DESCRIPTION
There are some endpoints where if the cursor is set to now the program will never receive new messages.

ex. https://horizon.stellar.org/accounts/{account_id}/offers