### PR TITLE
Clarify timeout in arg comments

### DIFF
--- a/stellar_sdk/client/requests_client.py
+++ b/stellar_sdk/client/requests_client.py
@@ -33,8 +33,8 @@ class RequestsClient(BaseSyncClient):
 
     :param pool_size: persistent connection to Horizon and connection pool
     :param num_retries: configurable request retry functionality
-    :param request_timeout: the timeout for all GET requests
-    :param post_timeout: the timeout for all POST requests
+    :param request_timeout: the timeout for all GET requests (for each retry)
+    :param post_timeout: the timeout for all POST requests (for each retry)
     :param backoff_factor: a backoff factor to apply between attempts after the second try
     :param session: the request session
     :param stream_session: the stream request session


### PR DESCRIPTION
`DEFAULT_POST_TIMEOUT_SECONDS` and _`HORIZON_SUBMIT_TRANSACTION_API_TIMEOUT_SECONDS` is set to around 30 seconds and default number of retries is 3, when sending  post requests it may can take 4*30 seconds and result in scenarios, where client is waiting for a long time, just to get tx_too_late error.