### PR TITLE
Fixed Soroban enum self.value

### DIFF
--- a/stellar_sdk/soroban/types/enum.py
+++ b/stellar_sdk/soroban/types/enum.py
@@ -19,7 +19,7 @@ class Enum(BaseScValAlias):
         self, key: str, value: Optional[Union[stellar_xdr.SCVal, BaseScValAlias]]
     ):
         self.key = key
-        if self.value is not None:
+        if value is not None:
             self.value: Optional[stellar_xdr.SCVal] = (
                 value.to_xdr_sc_val() if isinstance(value, BaseScValAlias) else value
             )


### PR DESCRIPTION
Got this error when creating an instance of `soroban.types.enum.Enum`:

```
File "/home/project/script.py", line 195, in build_enum
return Enum("custom", Symbol(v1))
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/home/project/.venv/lib/python3.11/site-packages/stellar_sdk/soroban/types/enum.py", line 22, in __init__
if self.value is not None:
   ^^^^^^^^^^

AttributeError: 'Enum' object has no attribute 'value'
```

I'm guessing that removing the `self.` is the correct solution.