### PR TITLE
improve: sort the dictionary based on the key when calling `scval.to_struct`.

### DIFF
--- a/stellar_sdk/scval.py
+++ b/stellar_sdk/scval.py
@@ -624,8 +624,11 @@ def to_struct(data: Dict[str, stellar_xdr.SCVal]) -> stellar_xdr.SCVal:
     :param data: The dict value to convert.
     :return: A new :class:`stellar_sdk.xdr.SCVal` XDR object.
     """
+    # sort the dict by key to ensure the order of the fields.
+    # see https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046-01.md#validity
+    sorted_data = dict(sorted(data.items()))
     v = dict()
-    for key, val in data.items():
+    for key, val in sorted_data.items():
         v[to_symbol(key)] = val
     return to_map(v)
 

--- a/tests/test_scval.py
+++ b/tests/test_scval.py
@@ -315,14 +315,14 @@ def test_tuple_struct():
 
 def test_struct():
     v = {
-        "data1": to_int32(1),
-        "data2": to_int256(23423432),
-        "data3": to_string("world"),
-        "data4": to_vec([to_int32(1), to_int256(23423432), to_string("world")]),
-        "data5": to_struct(
+        "simpleData": to_int32(1),
+        "a": to_int256(23423432),
+        "data": to_string("world"),
+        "a1": to_vec([to_int32(1), to_int256(23423432), to_string("world")]),
+        "A": to_struct(
             {
-                "inner_data1": to_int32(1),
-                "inner_data2": to_int256(23423432),
+                "inner_data2": to_int32(1),
+                "inner_data1": to_int256(23423432),
             }
         ),
     }
@@ -331,22 +331,22 @@ def test_struct():
         stellar_xdr.SCValType.SCV_MAP,
         map=xdr.SCMap(
             [
-                xdr.SCMapEntry(to_symbol("data1"), to_int32(1)),
-                xdr.SCMapEntry(to_symbol("data2"), to_int256(23423432)),
-                xdr.SCMapEntry(to_symbol("data3"), to_string("world")),
                 xdr.SCMapEntry(
-                    to_symbol("data4"),
-                    to_vec([to_int32(1), to_int256(23423432), to_string("world")]),
-                ),
-                xdr.SCMapEntry(
-                    to_symbol("data5"),
+                    to_symbol("A"),
                     to_map(
                         {
-                            to_symbol("inner_data1"): to_int32(1),
-                            to_symbol("inner_data2"): to_int256(23423432),
+                            to_symbol("inner_data1"): to_int256(23423432),
+                            to_symbol("inner_data2"): to_int32(1),
                         }
                     ),
                 ),
+                xdr.SCMapEntry(to_symbol("a"), to_int256(23423432)),
+                xdr.SCMapEntry(
+                    to_symbol("a1"),
+                    to_vec([to_int32(1), to_int256(23423432), to_string("world")]),
+                ),
+                xdr.SCMapEntry(to_symbol("data"), to_string("world")),
+                xdr.SCMapEntry(to_symbol("simpleData"), to_int32(1)),
             ]
         ),
     )


### PR DESCRIPTION
Closes #815 