### PR TITLE
Update soroban_restore_footprint.py

### DIFF
--- a/examples/soroban_restore_footprint.py
+++ b/examples/soroban_restore_footprint.py
@@ -33,7 +33,7 @@ ledger_key = stellar_xdr.LedgerKey(
         durability=stellar_xdr.ContractDataDurability.PERSISTENT,
     ),
 )
-soroban_data = SorobanDataBuilder().set_read_only([ledger_key]).build()
+soroban_data = SorobanDataBuilder().set_read_write([ledger_key]).build()
 
 tx = (
     TransactionBuilder(source, network_passphrase, base_fee=50000)


### PR DESCRIPTION
With the SorobanDataBuilder set to `.set_read_only()` the restore transaction returns as `malformed` With SorobanDataBuilder set to `set_read_write` it executes succesfully

Please review, as I don't understand fully understand this. I just observed this to work