### PR TITLE
feat: Expose AddressType for easy importing

### DIFF
--- a/stellar_sdk/address.py
+++ b/stellar_sdk/address.py
@@ -6,7 +6,7 @@ from . import xdr as stellar_xdr
 from .strkey import StrKey
 from .xdr import Hash
 
-__all__ = ["Address"]
+__all__ = ["Address", "AddressType"]
 
 
 class AddressType(IntEnum):


### PR DESCRIPTION
Allow importing from the main package:
`from stellar_sdk import AddressType`