### PR TITLE
refactor!: Updated `signer` parameter in auth to accept a callable re…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Release History
 ### Pending
 #### Update
 - feat!: support constructors in contract creation via `TransactionBuilder.append_create_contract_op`, the signature of the function has been changed.
+- refactor!: Updated `signer` parameter in auth to accept a callable returning (public_key, signatures) instead of just public_key.
 
 ### Version 11.1.0
 


### PR DESCRIPTION
…turning (public_key, signatures) instead of just public_key.