### PR TITLE
feat: add functions to send assets to contract address without relying on Stellar RPC.

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       rpc:
-        image: stellar/quickstart:testing@sha256:5333ec87069efd7bb61f6654a801dc093bf0aad91f43a5ba84806d3efe4a6322
+        image: stellar/quickstart:latest
         ports:
           - 8000:8000
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Release History
 
 ### Pending
 
+#### Update
+- feat: add `TransactionBuilder.append_payment_to_contract_op` and `TransactionBuilder.append_restore_asset_balance_entry_op` to send assets to contract accounts without relying on Stellar RPC. ([#1023](https://github.com/StellarCN/py-stellar-base/pull/1023))
+
 ### Version 12.1.0
 
 Released on December 27, 2024

--- a/examples/send_asset_to_contract_without_rpc.py
+++ b/examples/send_asset_to_contract_without_rpc.py
@@ -40,12 +40,15 @@ try:
     print("Success! Results:", response)
 except BadRequestError as e:
     print("Failed to send payment to contract. Results:", e)
+    assert e.result_xdr is not None
     tx_result = stellar_xdr.TransactionResult.from_xdr(e.result_xdr)
     # However, it may fail due to the entry being archived; for this reason, we should try to recover the data entry and then resend the transaction.
     # See https://developers.stellar.org/docs/learn/encyclopedia/storage/state-archival
     if (
         tx_result.result.code == stellar_xdr.TransactionResultCode.txFAILED
+        and tx_result.result.results
         and len(tx_result.result.results) == 1
+        and tx_result.result.results[0].tr
         and tx_result.result.results[0].tr.invoke_host_function_result
         and tx_result.result.results[0].tr.invoke_host_function_result.code
         == stellar_xdr.InvokeHostFunctionResultCode.INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED

--- a/examples/send_asset_to_contract_without_rpc.py
+++ b/examples/send_asset_to_contract_without_rpc.py
@@ -20,6 +20,7 @@ destination = "CDNVQW44C3HALYNVQ4SOBXY5EWYTGVYXX6JPESOLQDABJI5FC5LTRRUE"
 amount = "100.125"
 
 # 1. Try to send payment to a contract
+# example tx: https://stellar.expert/explorer/public/tx/18c62daf7d5a180acee1bb9918eccc2a19343a4f3c7012a9103ff2ba4024cec1
 tx = (
     TransactionBuilder(
         source_account, network_passphrase=network_passphrase, base_fee=base_fee
@@ -50,6 +51,7 @@ except BadRequestError as e:
     ):
         print("The contract has been archived, we need to restore it.")
         # 2. Restore the contract
+        # example tx: https://stellar.expert/explorer/public/tx/6992ccd04593452cb1f236ef266e2e9691cded85722c463aee5a01a1ccc006cf
         tx = (
             TransactionBuilder(
                 source_account, network_passphrase=network_passphrase, base_fee=base_fee
@@ -66,6 +68,7 @@ except BadRequestError as e:
         print("Restore balance entry success! Results:", response)
 
         # 3. Try to send payment to a contract again
+        # example tx: https://stellar.expert/explorer/public/tx/7c2a77d538f803da8cf2b14250c3a41b7fa0f2cf37dd437107e3c825efe60b91
         tx = (
             TransactionBuilder(
                 source_account, network_passphrase=network_passphrase, base_fee=base_fee

--- a/examples/send_asset_to_contract_without_rpc.py
+++ b/examples/send_asset_to_contract_without_rpc.py
@@ -1,0 +1,85 @@
+"""This example shows how to send an asset to a contract address without using the Stellar/Soroban RPC Server.
+
+If you can access the Stellar/Soroban RPC Server, you can refer to the code in `examples/soroban_payment.py` to send assets to the contract.
+"""
+
+from stellar_sdk import Asset, Keypair, Network, Server, TransactionBuilder
+from stellar_sdk import xdr as stellar_xdr
+from stellar_sdk.exceptions import BadRequestError
+
+kp = Keypair.from_secret("SCDG4ORIDX4QGPMMHQY36KDHHMTJEM4RQ2AWKH3G7AXHTVBJWEV6XOUM")
+horizon_url = "https://horizon-testnet.stellar.org"
+network_passphrase = Network.TESTNET_NETWORK_PASSPHRASE
+server = Server(horizon_url)
+base_fee = 1000
+
+source_account = server.load_account(kp.public_key)
+
+asset = Asset.native()
+destination = "CDNVQW44C3HALYNVQ4SOBXY5EWYTGVYXX6JPESOLQDABJI5FC5LTRRUE"
+amount = "100.125"
+
+# 1. Try to send payment to a contract
+tx = (
+    TransactionBuilder(
+        source_account, network_passphrase=network_passphrase, base_fee=base_fee
+    )
+    .append_payment_to_contract_op(
+        destination=destination,
+        asset=asset,
+        amount=amount,
+    )
+    .set_timeout(300)
+    .build()
+)
+tx.sign(kp)
+
+try:
+    response = server.submit_transaction(tx)
+    print("Success! Results:", response)
+except BadRequestError as e:
+    print("Failed to send payment to contract. Results:", e)
+    tx_result = stellar_xdr.TransactionResult.from_xdr(e.result_xdr)
+    # However, it may fail due to the state being archived; for this reason, we should try to recover the data entry and then resend the transaction.
+    if (
+        tx_result.result.code == stellar_xdr.TransactionResultCode.txFAILED
+        and len(tx_result.result.results) == 1
+        and tx_result.result.results[0].tr.invoke_host_function_result
+        and tx_result.result.results[0].tr.invoke_host_function_result.code
+        == stellar_xdr.InvokeHostFunctionResultCode.INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED
+    ):
+        print("The contract has been archived, we need to restore it.")
+        # 2. Restore the contract
+        tx = (
+            TransactionBuilder(
+                source_account, network_passphrase=network_passphrase, base_fee=base_fee
+            )
+            .append_restore_asset_balance_entry_op(
+                balance_owner=destination,
+                asset=asset,
+            )
+            .set_timeout(300)
+            .build()
+        )
+        tx.sign(kp)
+        response = server.submit_transaction(tx)
+        print("Restore balance entry success! Results:", response)
+
+        # 3. Try to send payment to a contract again
+        tx = (
+            TransactionBuilder(
+                source_account, network_passphrase=network_passphrase, base_fee=base_fee
+            )
+            .append_payment_to_contract_op(
+                destination=destination,
+                asset=asset,
+                amount=amount,
+            )
+            .set_timeout(300)
+            .build()
+        )
+        tx.sign(kp)
+        response = server.submit_transaction(tx)
+        print("Send payment to contract success! Results:", response)
+    else:
+        print("Unknown error:", e)

--- a/examples/send_asset_to_contract_without_rpc.py
+++ b/examples/send_asset_to_contract_without_rpc.py
@@ -41,7 +41,8 @@ try:
 except BadRequestError as e:
     print("Failed to send payment to contract. Results:", e)
     tx_result = stellar_xdr.TransactionResult.from_xdr(e.result_xdr)
-    # However, it may fail due to the state being archived; for this reason, we should try to recover the data entry and then resend the transaction.
+    # However, it may fail due to the entry being archived; for this reason, we should try to recover the data entry and then resend the transaction.
+    # See https://developers.stellar.org/docs/learn/encyclopedia/storage/state-archival
     if (
         tx_result.result.code == stellar_xdr.TransactionResultCode.txFAILED
         and len(tx_result.result.results) == 1

--- a/stellar_sdk/transaction_builder.py
+++ b/stellar_sdk/transaction_builder.py
@@ -1482,6 +1482,8 @@ class TransactionBuilder:
         If you encounter the `entry_archived` error when submitting this transaction, you should consider calling the :func:`append_restore_asset_balance_entry_op` method to restore the entry,
         and then use the :func:`append_payment_to_contract_op` method to send assets again.
 
+        You can find the example code in the `examples/send_asset_to_contract_without_rpc.py <https://github.com/StellarCN/py-stellar-base/blob/main/examples/>`__.
+
         .. note::
             1. This method should only be used to send assets to contract addresses (starting with 'C'). For sending assets to regular account addresses (starting with 'G'), please use the :func:`append_payment_op` method.
             2. This method is suitable for sending assets to a contract account when you don't have access to a Stellar RPC server. If you have access to a Stellar RPC server, it is recommended to use the :class:`stellar_sdk.contract.ContractClient` to build transactions for sending tokens to contracts.
@@ -1501,7 +1503,7 @@ class TransactionBuilder:
         :return: This builder instance.
         """
         if not StrKey.is_valid_contract(destination):
-            raise ValueError("`destination` is invalid contract address.")
+            raise ValueError("`destination` is not a valid contract address.")
 
         from_address = (
             self.source_account.account.account_id

--- a/stellar_sdk/transaction_builder.py
+++ b/stellar_sdk/transaction_builder.py
@@ -6,7 +6,7 @@ import warnings
 from decimal import Decimal
 from typing import List, Optional, Sequence, Union
 
-from . import StrKey
+from . import StrKey, scval
 from . import xdr as stellar_xdr
 from .account import Account
 from .address import Address
@@ -1462,6 +1462,166 @@ class TransactionBuilder:
         """
         op = RestoreFootprint(source)
         return self.append_operation(op)
+
+    def append_payment_to_contract_op(
+        self,
+        destination: str,
+        asset: Asset,
+        amount: Union[str, Decimal],
+        instructions: int = 400_000,
+        read_bytes: int = 1_000,
+        write_bytes: int = 1_000,
+        resource_fee: int = 5_000_000,
+        source: Optional[Union[MuxedAccount, str]] = None,
+    ) -> "TransactionBuilder":
+        """Append an :class:`InvokeHostFunction <stellar_sdk.operation.InvokeHostFunction>` operation to send assets to a contract address.
+
+        The original intention of this interface design is to send assets to the contract account when the Stellar RPC server is inaccessible.
+        Without Stellar RPC, we cannot accurately estimate the required resources, so we have preset some values that may be slightly higher than the actual resource consumption.
+
+        .. note::
+            1. This method should only be used to send assets to contract addresses (starting with 'C'). For sending assets to regular account addresses (starting with 'G'), please use the :func:`append_payment_op` method.
+            2. This method is suitable for sending assets to a contract account when you don't have access to a Stellar RPC server. If you have access to a Stellar RPC server, it is recommended to use the :class:`stellar_sdk.contract.ContractClient` to build transactions for sending tokens to contracts.
+            3. This method may consume slightly more transaction fee than actually required.
+
+        :param destination: The contract address to send the assets to.
+        :param asset: The asset to send.
+        :param amount: The amount of the asset to send.
+        :param instructions: The instructions required to execute the contract function.
+        :param read_bytes: The read bytes required to execute the contract function.
+        :param write_bytes: The write bytes required to execute the contract function.
+        :param resource_fee: The maximum fee (in stroops) that can be paid for the
+            resources consumed by the contract function, defaults to 0.5 XLM.
+            The actual consumption is generally much lower than this value.
+        :param source: The source account for the operation. Defaults to the
+            transaction's source account.
+        :return: This builder instance.
+        """
+        if not StrKey.is_valid_contract(destination):
+            raise ValueError("`destination` is invalid contract address.")
+
+        from_address = (
+            self.source_account.account.account_id
+            if source is None
+            else (
+                source.account_id
+                if isinstance(source, MuxedAccount)
+                else MuxedAccount.from_account(source).account_id
+            )
+        )
+
+        # https://developers.stellar.org/docs/tokens/token-interface
+        contract_id = asset.contract_id(self.network_passphrase)
+        function_name = "transfer"
+        parameters = [
+            scval.to_address(from_address),  # from
+            scval.to_address(destination),  # to
+            scval.to_int128(Operation.to_xdr_amount(amount)),  # amount
+        ]
+
+        self.append_invoke_contract_function_op(
+            contract_id=contract_id,
+            function_name=function_name,
+            parameters=parameters,
+            auth=[
+                stellar_xdr.SorobanAuthorizationEntry(
+                    credentials=stellar_xdr.SorobanCredentials(
+                        stellar_xdr.SorobanCredentialsType.SOROBAN_CREDENTIALS_SOURCE_ACCOUNT
+                    ),
+                    root_invocation=stellar_xdr.SorobanAuthorizedInvocation(
+                        stellar_xdr.SorobanAuthorizedFunction(
+                            stellar_xdr.SorobanAuthorizedFunctionType.SOROBAN_AUTHORIZED_FUNCTION_TYPE_CONTRACT_FN,
+                            contract_fn=stellar_xdr.InvokeContractArgs(
+                                contract_address=Address(
+                                    contract_id
+                                ).to_xdr_sc_address(),
+                                function_name=stellar_xdr.SCSymbol(
+                                    sc_symbol=function_name.encode("utf-8")
+                                ),
+                                args=parameters,
+                            ),
+                        ),
+                        sub_invocations=[],
+                    ),
+                )
+            ],
+        )
+
+        contract_instance_ledger_key = stellar_xdr.LedgerKey(
+            type=stellar_xdr.LedgerEntryType.CONTRACT_DATA,
+            contract_data=stellar_xdr.LedgerKeyContractData(
+                contract=Address(contract_id).to_xdr_sc_address(),
+                key=stellar_xdr.SCVal(
+                    stellar_xdr.SCValType.SCV_LEDGER_KEY_CONTRACT_INSTANCE
+                ),
+                durability=stellar_xdr.ContractDataDurability.PERSISTENT,
+            ),
+        )
+
+        balance_ledger_key = stellar_xdr.LedgerKey(
+            type=stellar_xdr.LedgerEntryType.CONTRACT_DATA,
+            contract_data=stellar_xdr.LedgerKeyContractData(
+                contract=Address(contract_id).to_xdr_sc_address(),
+                key=stellar_xdr.SCVal(
+                    stellar_xdr.SCValType.SCV_VEC,
+                    vec=scval.to_vec(
+                        [scval.to_symbol("Balance"), scval.to_address(destination)]
+                    ).vec,
+                ),
+                durability=stellar_xdr.ContractDataDurability.PERSISTENT,
+            ),
+        )
+
+        if asset.is_native():
+            read_only = [contract_instance_ledger_key]
+            read_write = [
+                stellar_xdr.LedgerKey(
+                    type=stellar_xdr.LedgerEntryType.ACCOUNT,
+                    account=stellar_xdr.LedgerKeyAccount(
+                        Keypair.from_public_key(from_address).xdr_account_id()
+                    ),
+                ),
+                balance_ledger_key,
+            ]
+        else:
+            assert asset.issuer is not None
+            read_only = [
+                # In theory, it is only needed the first time it is sent to the receiving account,
+                # but here we read it every time to simplify the logic.
+                stellar_xdr.LedgerKey(
+                    type=stellar_xdr.LedgerEntryType.ACCOUNT,
+                    account=stellar_xdr.LedgerKeyAccount(
+                        Keypair.from_public_key(asset.issuer).xdr_account_id()
+                    ),
+                ),
+                contract_instance_ledger_key,
+            ]
+            read_write = [
+                stellar_xdr.LedgerKey(
+                    type=stellar_xdr.LedgerEntryType.TRUSTLINE,
+                    trust_line=stellar_xdr.LedgerKeyTrustLine(
+                        account_id=Keypair.from_public_key(
+                            from_address
+                        ).xdr_account_id(),
+                        asset=asset.to_trust_line_asset_xdr_object(),
+                    ),
+                ),
+                balance_ledger_key,
+            ]
+
+        soroban_data = (
+            SorobanDataBuilder()
+            .set_read_only(read_only)
+            .set_read_write(read_write)
+            # This means we may pay up to {resource_fee / 10 ** 7} XLM, excluding fees.
+            .set_resource_fee(resource_fee)
+            # This is higher than actually needed, but the loss is not significant.
+            # We should leave some space to handle various situations, including future contract upgrades.
+            .set_resources(instructions, read_bytes, write_bytes)
+            .build()
+        )
+        self.set_soroban_data(soroban_data)
+        return self
 
     def __repr__(self):
         return (

--- a/tests/integration_utils.py
+++ b/tests/integration_utils.py
@@ -1,0 +1,79 @@
+import requests
+
+from stellar_sdk import (
+    Asset,
+    Keypair,
+    Network,
+    Server,
+    SorobanServer,
+    TransactionBuilder,
+    scval,
+)
+from stellar_sdk.contract import ContractClient
+from stellar_sdk.contract.exceptions import SimulationFailedError
+
+RPC_URL = "http://127.0.0.1:8000/soroban/rpc"
+HORIZON_URL = "http://127.0.0.1:8000"
+NETWORK_PASSPHRASE = Network.STANDALONE_NETWORK_PASSPHRASE
+
+
+def fund_account(account_id: str):
+    resp = requests.get(f"http://127.0.0.1:8000/friendbot?addr={account_id}")
+    resp.raise_for_status()
+
+
+def create_asset_contract(asset: Asset, kp: Keypair):
+    try:
+        with SorobanServer(RPC_URL) as server:
+            return ContractClient.create_stellar_asset_contract_from_asset(
+                asset, kp.public_key, kp, server
+            )
+    except SimulationFailedError:
+        # pass, maybe the contract already exists
+        return asset.contract_id(NETWORK_PASSPHRASE)
+
+
+def get_balance_for_contract(contract_id: str, asset: Asset, source: str) -> int:
+    with ContractClient(
+        asset.contract_id(NETWORK_PASSPHRASE), RPC_URL, NETWORK_PASSPHRASE
+    ) as client:
+        return client.invoke(
+            "balance",
+            [scval.to_address(contract_id)],
+            source=source,
+            parse_result_xdr_fn=lambda x: scval.from_int128(x),
+        ).result()
+
+
+def issue_asset(asset_code: str, issuer_kp: Keypair, receiver_kp: Keypair, amount: str):
+    with Server(HORIZON_URL) as server:
+        asset = Asset(asset_code, issuer_kp.public_key)
+        # First, the receiving account must trust the asset
+        trust_transaction = (
+            TransactionBuilder(
+                source_account=server.load_account(receiver_kp.public_key),
+                network_passphrase=NETWORK_PASSPHRASE,
+                base_fee=100,
+            )
+            .append_change_trust_op(asset=asset)
+            .set_timeout(30)
+            .build()
+        )
+
+        trust_transaction.sign(receiver_kp)
+        server.submit_transaction(trust_transaction)
+
+        payment_transaction = (
+            TransactionBuilder(
+                source_account=server.load_account(issuer_kp.public_key),
+                network_passphrase=NETWORK_PASSPHRASE,
+                base_fee=100,
+            )
+            .append_payment_op(
+                destination=receiver_kp.public_key, amount=amount, asset=asset
+            )
+            .set_timeout(30)
+            .build()
+        )
+        payment_transaction.sign(issuer_kp)
+        server.submit_transaction(payment_transaction)


### PR DESCRIPTION
Send:
```python
from stellar_sdk import *

server_url = "https://horizon.stellar.org"
network_passphrase = Network.PUBLIC_NETWORK_PASSPHRASE

alice_kp = Keypair.from_mnemonic_phrase("")

server = Server(server_url)
source_account = server.load_account(alice_kp.public_key)
tx = TransactionBuilder(source_account, network_passphrase=network_passphrase).append_payment_to_contract_op(
    "CASURCIREQG46FT3B7TFRIEETDUIAYRTCEZL4EWBEAJVX77CWPAQWD6R",
    asset=Asset.native(),
    amount="0.0001",
).set_timeout(300).build()
tx.sign(alice_kp)
print(tx.to_xdr())
resp = server.submit_transaction(tx)
print(resp)
```

Restore:
```python
from stellar_sdk import *

server_url = "https://horizon.stellar.org"
network_passphrase = Network.PUBLIC_NETWORK_PASSPHRASE

alice_kp = Keypair.from_mnemonic_phrase()

server = Server(server_url)
source_account = server.load_account(alice_kp.public_key)
tx = TransactionBuilder(source_account, network_passphrase=network_passphrase).append_restore_asset_balance_entry_op(
    "CASURCIREQG46FT3B7TFRIEETDUIAYRTCEZL4EWBEAJVX77CWPAQWD6R",
    asset=Asset.native(),
).set_timeout(300).build()
tx.sign(alice_kp)
print(tx.to_xdr())
resp = server.submit_transaction(tx)
print(resp)
```