### PR TITLE
refactor: use `tomllib` instead of `toml` library in Python 3.11 and above.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pynacl>=1.4.0",
     "requests>=2.0.0",
     "requests-sse>=0.3",
-    "toml>=0.10.2",
+    "toml>=0.10.2; python_version < '3.11'",
     "typing-extensions>=4.0.0",
     "xdrlib3>=0.1.1",
 ]

--- a/stellar_sdk/sep/stellar_toml.py
+++ b/stellar_sdk/sep/stellar_toml.py
@@ -67,7 +67,7 @@ async def fetch_stellar_toml_async(
     :param use_http: Specifies whether the request should go over plain HTTP vs HTTPS.
         Note it is recommended that you **always** use HTTPS.
     :param client: Http Client used to send the request.
-    :return: The stellar.toml file as an dict object.
+    :return: The stellar.toml file as a dict object.
     :raises: :exc:`StellarTomlNotFoundError <stellar_sdk.sep.exceptions.StellarTomlNotFoundError>`:
         if the Stellar toml file could not be found.
     """

--- a/stellar_sdk/sep/stellar_toml.py
+++ b/stellar_sdk/sep/stellar_toml.py
@@ -8,9 +8,13 @@ Updated: 2019-06-12
 Version: 2.1.0
 """
 
+import sys
 from typing import Any, MutableMapping
 
-import toml
+if sys.version_info >= (3, 11):
+    from tomllib import loads as toml_loads
+else:
+    from toml import loads as toml_loads
 
 from ..client.aiohttp_client import AiohttpClient
 from ..client.base_async_client import BaseAsyncClient
@@ -63,7 +67,7 @@ async def fetch_stellar_toml_async(
     :param use_http: Specifies whether the request should go over plain HTTP vs HTTPS.
         Note it is recommended that you **always** use HTTPS.
     :param client: Http Client used to send the request.
-    :return: The stellar.toml file as an object via :func:`toml.loads`.
+    :return: The stellar.toml file as an dict object.
     :raises: :exc:`StellarTomlNotFoundError <stellar_sdk.sep.exceptions.StellarTomlNotFoundError>`:
         if the Stellar toml file could not be found.
     """
@@ -79,7 +83,7 @@ def _handle_raw_response(raw_resp: Response) -> MutableMapping[str, Any]:
     if raw_resp.status_code == 404:
         raise StellarTomlNotFoundError
     resp = raw_resp.text
-    return toml.loads(resp)
+    return toml_loads(resp)
 
 
 def _build_request_url(domain: str, use_http: bool = False) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -2957,7 +2957,7 @@ dependencies = [
     { name = "pynacl" },
     { name = "requests" },
     { name = "requests-sse" },
-    { name = "toml" },
+    { name = "toml", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "xdrlib3" },
@@ -3013,7 +3013,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.0.0" },
     { name = "requests-sse", specifier = ">=0.3" },
     { name = "shamir-mnemonic", marker = "extra == 'shamir'", specifier = ">=0.3.0" },
-    { name = "toml", specifier = ">=0.10.2" },
+    { name = "toml", marker = "python_full_version < '3.11'", specifier = ">=0.10.2" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "xdrlib3", specifier = ">=0.1.1" },
 ]


### PR DESCRIPTION
https://docs.python.org/3/library/tomllib.html