### PR TITLE
refactor!: when an invalid account ID is passed into the `MuxedAccoun…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Release History
   - `TransactionBuilder.append_payment_to_contract_op` now uses `disk_read_bytes` instead of `read_bytes` in its function signature.
   - `TransactionBuilder.append_restore_asset_balance_entry_op` now uses `disk_read_bytes` instead of `read_bytes` in its function signature.
 - refactor!: `StrKey.decode_muxed_account` and `StrKey.encode_muxed_account` have been marked as deprecated, please use `stellar_sdk.MuxedAccount` instead. They will be removed in the next major release.
+- refactor!: when an invalid account ID is passed into the `MuxedAccount.from_account`, it raises a `ValueError` now. 
 
 ### Version 12.3.0
 

--- a/stellar_sdk/muxed_account.py
+++ b/stellar_sdk/muxed_account.py
@@ -93,7 +93,7 @@ class MuxedAccount:
         if StrKey.is_valid_ed25519_public_key(account):
             # If the account is a valid ed25519 public key, return a MuxedAccount with no muxed id.
             return cls(account_id=account, account_muxed_id=None)
-        else:
+        elif StrKey.is_valid_med25519_public_key(account):
             raw_bytes = StrKey.decode_med25519_public_key(account)
             muxed = stellar_xdr.MuxedAccountMed25519(
                 id=stellar_xdr.Uint64.from_xdr_bytes(raw_bytes[-8:]),
@@ -102,6 +102,8 @@ class MuxedAccount:
             account_id = StrKey.encode_ed25519_public_key(muxed.ed25519.uint256)
             account_muxed_id = muxed.id.uint64
             return cls(account_id=account_id, account_muxed_id=account_muxed_id)
+        else:
+            raise ValueError(f"This is not a valid account: {account}")
 
     def to_xdr_object(self) -> stellar_xdr.MuxedAccount:
         """Returns the xdr object for this MuxedAccount object.

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -2,10 +2,6 @@ import pytest
 
 from stellar_sdk import Account, MuxedAccount
 from stellar_sdk.account import Thresholds
-from stellar_sdk.exceptions import (
-    Ed25519PublicKeyInvalidError,
-    MuxedEd25519AccountInvalidError,
-)
 from stellar_sdk.sep.ed25519_public_key_signer import Ed25519PublicKeySigner
 
 
@@ -102,8 +98,8 @@ class TestAccount:
     def test_account_with_invalid_ed25519_public_key_raise(self):
         invalid_account_id = "GA7YNBW5CBTJZ3ZZOWX3ZNBKD6OE7A7IHUQVWMY62W2ZBG2SGZVOOBAD"
         with pytest.raises(
-            Ed25519PublicKeyInvalidError,
-            match=f"Invalid Ed25519 Public Key: {invalid_account_id}",
+            ValueError,
+            match=f"This is not a valid account: {invalid_account_id}",
         ):
             Account(invalid_account_id, 0)
 
@@ -112,8 +108,8 @@ class TestAccount:
             "MA7YNBW5CBTJZ3ZZOWX3ZNBKD6OE7A7IHUQVWMY62W2ZBG2SGZVOOAAAAAAAAEINVALID"
         )
         with pytest.raises(
-            MuxedEd25519AccountInvalidError,
-            match=f"Invalid Muxed Account: {invalid_muxed_account}",
+            ValueError,
+            match=f"This is not a valid account: {invalid_muxed_account}",
         ):
             Account(invalid_muxed_account, 0)
 

--- a/tests/test_muxed_account.py
+++ b/tests/test_muxed_account.py
@@ -56,7 +56,7 @@ class TestMuxedAccount:
 
     def test_from_account_invalid_account_raise(self):
         invalid_account = "A" * 100
-        with pytest.raises(ValueError, match="Invalid Med25519 Public Key"):
+        with pytest.raises(ValueError, match="This is not a valid account"):
             MuxedAccount.from_account(invalid_account)
 
     def test_set_account_muxed_raise(self):


### PR DESCRIPTION
…t.from_account`, it raises a `ValueError` now.