### PR TITLE
feat: `getEvents` RPC method - expose `endLedger` param

### DIFF
--- a/stellar_sdk/soroban_rpc.py
+++ b/stellar_sdk/soroban_rpc.py
@@ -92,8 +92,11 @@ class PaginationMixin:
     @model_validator(mode="after")
     def verify_ledger_or_cursor(self) -> Self:
         pagination = getattr(self, "pagination", None)
-        if pagination and (getattr(self, "start_ledger") and pagination.cursor):
-            raise ValueError("start_ledger and cursor cannot both be set")
+        if pagination and pagination.cursor:
+            if getattr(self, "start_ledger"):
+                raise ValueError("start_ledger and cursor cannot both be set")
+            if getattr(self, "end_ledger"):
+                raise ValueError("end_ledger and cursor cannot both be set")
         return self
 
 
@@ -105,6 +108,7 @@ class GetEventsRequest(PaginationMixin, BaseModel):
     """
 
     start_ledger: Optional[int] = Field(alias="startLedger", default=None)
+    end_ledger: Optional[int] = Field(alias="endLedger", default=None)
     pagination: Optional[PaginationOptions] = None
     filters: Optional[Sequence[EventFilter]] = None
 

--- a/stellar_sdk/soroban_server.py
+++ b/stellar_sdk/soroban_server.py
@@ -81,6 +81,7 @@ class SorobanServer:
     def get_events(
         self,
         start_ledger: Optional[int] = None,
+        end_ledger: Optional[int] = None,
         filters: Optional[Sequence[EventFilter]] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
@@ -89,7 +90,8 @@ class SorobanServer:
 
         See `Soroban RPC Documentation - getEvents <https://developers.stellar.org/docs/data/rpc/api-reference/methods/getEvents>`_
 
-        :param start_ledger: The first ledger to include in the results.
+        :param start_ledger: Ledger sequence number to start fetching responses from (inclusive). This method will return an error if startLedger is less than the oldest ledger stored in this node, or greater than the latest ledger seen by this node. If a cursor is included in the request, startLedger must be omitted.
+        :param end_ledger: Ledger sequence number represents the end of search window (exclusive). If a cursor is included in the request, this must be omitted.
         :param filters: A list of filters to apply to the results.
         :param cursor: A cursor value for use in pagination.
         :param limit: The maximum number of records to return.
@@ -99,6 +101,7 @@ class SorobanServer:
         pagination = PaginationOptions(cursor=cursor, limit=limit)
         data = GetEventsRequest(
             startLedger=start_ledger,
+            endLedger=end_ledger,
             filters=filters,
             pagination=pagination,
         )

--- a/stellar_sdk/soroban_server_async.py
+++ b/stellar_sdk/soroban_server_async.py
@@ -81,6 +81,7 @@ class SorobanServerAsync:
     async def get_events(
         self,
         start_ledger: Optional[int] = None,
+        end_ledger: Optional[int] = None,
         filters: Optional[Sequence[EventFilter]] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
@@ -89,7 +90,8 @@ class SorobanServerAsync:
 
         See `Soroban RPC Documentation - getEvents <https://developers.stellar.org/docs/data/rpc/api-reference/methods/getEvents>`_
 
-        :param start_ledger: The first ledger to include in the results.
+        :param start_ledger: Ledger sequence number to start fetching responses from (inclusive). This method will return an error if startLedger is less than the oldest ledger stored in this node, or greater than the latest ledger seen by this node. If a cursor is included in the request, startLedger must be omitted.
+        :param end_ledger: Ledger sequence number represents the end of search window (exclusive). If a cursor is included in the request, this must be omitted.
         :param filters: A list of filters to apply to the results.
         :param cursor: A cursor value for use in pagination.
         :param limit: The maximum number of records to return.
@@ -99,6 +101,7 @@ class SorobanServerAsync:
         pagination = PaginationOptions(cursor=cursor, limit=limit)
         data = GetEventsRequest(
             startLedger=start_ledger,
+            endLedger=end_ledger,
             filters=filters,
             pagination=pagination,
         )


### PR DESCRIPTION
From the official API reference:
`endLedger` - Ledger sequence number represents the end of search window (exclusive). If a cursor is included in the request, endLedger must be omitted.