### PR TITLE
refactor: refactor the type hints to adopt modern Python 3.9 and 3.10 syntax.

### DIFF
--- a/examples/soroban_invoke_contract_function.py
+++ b/examples/soroban_invoke_contract_function.py
@@ -11,8 +11,6 @@
 3. Modify the necessary parameters in this script, then run it.
 """
 
-from typing import List
-
 from stellar_sdk import Network, scval
 from stellar_sdk.contract import AssembledTransaction, ContractClient
 
@@ -25,7 +23,7 @@ def parse_result_xdr(result):
     return [scval.from_string(s).decode() for s in scval.from_vec(result)]
 
 
-assembled: AssembledTransaction[List[str]] = ContractClient(
+assembled: AssembledTransaction[list[str]] = ContractClient(
     contract_id,
     rpc_server_url,
     network_passphrase,

--- a/stellar_sdk/account.py
+++ b/stellar_sdk/account.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from .muxed_account import MuxedAccount
 from .sep.ed25519_public_key_signer import Ed25519PublicKeySigner
@@ -37,16 +37,16 @@ class Account:
 
     def __init__(
         self,
-        account: Union[str, MuxedAccount],
+        account: str | MuxedAccount,
         sequence: int,
-        raw_data: Optional[Dict[str, Any]] = None,
+        raw_data: dict[str, Any] | None = None,
     ) -> None:
         if isinstance(account, str):
             self.account: MuxedAccount = MuxedAccount.from_account(account)
         else:
             self.account = account
         self.sequence: int = sequence
-        self.raw_data: Optional[Dict[str, Any]] = raw_data
+        self.raw_data: dict[str, Any] | None = raw_data
 
     @property
     def universal_account_id(self) -> str:
@@ -73,7 +73,7 @@ class Account:
             self.raw_data["thresholds"]["high_threshold"],
         )
 
-    def load_ed25519_public_key_signers(self) -> List[Ed25519PublicKeySigner]:
+    def load_ed25519_public_key_signers(self) -> list[Ed25519PublicKeySigner]:
         """Load ed25519 public key signers."""
         if self.raw_data is None:
             raise ValueError('"raw_data" is None, unable to get signers from it.')

--- a/stellar_sdk/address.py
+++ b/stellar_sdk/address.py
@@ -1,6 +1,5 @@
 import binascii
 from enum import IntEnum
-from typing import Union
 
 from . import xdr as stellar_xdr
 from .strkey import StrKey
@@ -73,7 +72,7 @@ class Address:
             raise ValueError("Unsupported address type.")
 
     @staticmethod
-    def from_raw_account(account: Union[bytes, str]) -> "Address":
+    def from_raw_account(account: bytes | str) -> "Address":
         """Creates a new account Address object from raw bytes.
 
         :param account: The raw bytes of the account, it can be a byte array or a hex encoded string.
@@ -84,7 +83,7 @@ class Address:
         return Address(StrKey.encode_ed25519_public_key(account))
 
     @staticmethod
-    def from_raw_contract(contract: Union[bytes, str]) -> "Address":
+    def from_raw_contract(contract: bytes | str) -> "Address":
         """Creates a new contract Address object from a buffer of raw bytes.
 
         :param contract: The raw bytes of the contract.
@@ -95,7 +94,7 @@ class Address:
         return Address(StrKey.encode_contract(contract))
 
     @staticmethod
-    def from_raw_muxed_account(muxed_account: Union[bytes, str]) -> "Address":
+    def from_raw_muxed_account(muxed_account: bytes | str) -> "Address":
         """Creates a new muxed account Address object from raw bytes.
 
         :param muxed_account: The raw bytes of the muxed account.
@@ -106,7 +105,7 @@ class Address:
         return Address(StrKey.encode_med25519_public_key(muxed_account))
 
     @staticmethod
-    def from_raw_claimable_balance(claimable_balance: Union[bytes, str]) -> "Address":
+    def from_raw_claimable_balance(claimable_balance: bytes | str) -> "Address":
         """Creates a new claimable balance Address object from raw bytes.
 
         :param claimable_balance: The raw bytes of the claimable balance.
@@ -117,7 +116,7 @@ class Address:
         return Address(StrKey.encode_claimable_balance(claimable_balance))
 
     @staticmethod
-    def from_raw_liquidity_pool(liquidity_pool: Union[bytes, str]) -> "Address":
+    def from_raw_liquidity_pool(liquidity_pool: bytes | str) -> "Address":
         """Creates a new liquidity pool Address object from raw bytes.
 
         :param liquidity_pool: The raw bytes of the liquidity pool.

--- a/stellar_sdk/asset.py
+++ b/stellar_sdk/asset.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, Optional, Type, Union
+from typing import Type
 
 from . import xdr as stellar_xdr
 from .exceptions import AssetCodeInvalidError, AssetIssuerInvalidError
@@ -22,9 +22,9 @@ class Asset:
         native_asset = Asset.native()  # You can also create a native asset through Asset("XLM").
         credit_alphanum4_asset = Asset("USD", "GBSKJPM2FM6O2C6GVZNAUAMGXZ6I4QIUPMNWVDN2NZULPWWTV3GI2SOX")
         credit_alphanum12_asset = Asset("BANANA", "GA6VT2PDD73TNNRYLPJPJYAAI7EGKBATZ7V562S7XY7TJD4GNOXRG6OS")
-        print(f"Asset type: {credit_alphanum4_asset.type}\\n"
-              f"Asset code: {credit_alphanum4_asset.code}\\n"
-              f"Asset issuer: {credit_alphanum4_asset.issuer}\\n"
+        print(f"Asset type: {credit_alphanum4_asset.type}\n"
+              f"Asset code: {credit_alphanum4_asset.code}\n"
+              f"Asset issuer: {credit_alphanum4_asset.issuer}\n"
               f"Is native asset: {credit_alphanum4_asset.is_native()}")
 
     For more information about the formats used for asset codes and how issuers
@@ -42,7 +42,7 @@ class Asset:
         https://developers.stellar.org/docs/glossary/assets/
     """
 
-    def __init__(self, code: str, issuer: Optional[str] = None) -> None:
+    def __init__(self, code: str, issuer: str | None = None) -> None:
         Asset.check_if_asset_code_is_valid(code)
 
         if code != "XLM" and issuer is None:
@@ -54,7 +54,7 @@ class Asset:
             raise AssetIssuerInvalidError("The issuer should be a correct public key.")
 
         self.code: str = code
-        self.issuer: Optional[str] = issuer
+        self.issuer: str | None = issuer
         self._type: str = self.guess_asset_type()
 
     @staticmethod
@@ -118,12 +118,12 @@ class Asset:
             asset_type = "credit_alphanum4"
         return asset_type
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, str | None]:
         """Generate a dict for this object's attributes.
 
         :return: A dict representing an :class:`Asset`
         """
-        rv: Dict[str, Optional[str]] = {"type": self.type}
+        rv: dict[str, str | None] = {"type": self.type}
         if not self.is_native():
             rv["code"] = self.code
             rv["issuer"] = self.issuer
@@ -173,14 +173,12 @@ class Asset:
 
     def _to_xdr_object(
         self,
-        xdr_asset: Union[
-            Type[stellar_xdr.Asset],
-            Type[stellar_xdr.ChangeTrustAsset],
-            Type[stellar_xdr.TrustLineAsset],
-        ],
-    ) -> Union[
-        stellar_xdr.Asset, stellar_xdr.ChangeTrustAsset, stellar_xdr.TrustLineAsset
-    ]:
+        xdr_asset: (
+            Type[stellar_xdr.Asset]
+            | Type[stellar_xdr.ChangeTrustAsset]
+            | Type[stellar_xdr.TrustLineAsset]
+        ),
+    ) -> stellar_xdr.Asset | stellar_xdr.ChangeTrustAsset | stellar_xdr.TrustLineAsset:
         if self.is_native():
             asset_type = stellar_xdr.AssetType.ASSET_TYPE_NATIVE
             return xdr_asset(type=asset_type)
@@ -204,9 +202,11 @@ class Asset:
     @classmethod
     def from_xdr_object(
         cls,
-        xdr_object: Union[
-            stellar_xdr.Asset, stellar_xdr.ChangeTrustAsset, stellar_xdr.TrustLineAsset
-        ],
+        xdr_object: (
+            stellar_xdr.Asset
+            | stellar_xdr.ChangeTrustAsset
+            | stellar_xdr.TrustLineAsset
+        ),
     ) -> "Asset":
         """Create a :class:`Asset` from an XDR Asset/ChangeTrustAsset/TrustLineAsset object.
 

--- a/stellar_sdk/auth.py
+++ b/stellar_sdk/auth.py
@@ -1,6 +1,6 @@
 import copy
 import random
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable
 
 from . import scval
 from . import xdr as stellar_xdr
@@ -14,8 +14,8 @@ __all__ = ["authorize_entry", "authorize_invocation"]
 
 
 def authorize_entry(
-    entry: Union[stellar_xdr.SorobanAuthorizationEntry, str],
-    signer: Union[Keypair, Callable[[stellar_xdr.HashIDPreimage], Tuple[str, bytes]]],
+    entry: stellar_xdr.SorobanAuthorizationEntry | str,
+    signer: Keypair | Callable[[stellar_xdr.HashIDPreimage], tuple[str, bytes]],
     valid_until_ledger_sequence: int,
     network_passphrase: str,
 ) -> stellar_xdr.SorobanAuthorizationEntry:
@@ -97,8 +97,8 @@ def authorize_entry(
 
 
 def authorize_invocation(
-    signer: Union[Keypair, Callable[[stellar_xdr.HashIDPreimage], Tuple[str, bytes]]],
-    public_key: Optional[str],
+    signer: Keypair | Callable[[stellar_xdr.HashIDPreimage], tuple[str, bytes]],
+    public_key: str | None,
     valid_until_ledger_sequence: int,
     invocation: stellar_xdr.SorobanAuthorizedInvocation,
     network_passphrase: str,

--- a/stellar_sdk/base_server.py
+++ b/stellar_sdk/base_server.py
@@ -1,5 +1,6 @@
+from collections.abc import Coroutine, Generator
 from decimal import Decimal
-from typing import Any, Coroutine, Dict, Generator, List, Optional, Tuple, Union
+from typing import Any
 
 from .account import Account
 from .asset import Asset
@@ -45,11 +46,9 @@ __all__ = ["BaseServer"]
 class BaseServer:
     def submit_transaction(
         self,
-        transaction_envelope: Union[
-            TransactionEnvelope, FeeBumpTransactionEnvelope, str
-        ],
+        transaction_envelope: TransactionEnvelope | FeeBumpTransactionEnvelope | str,
         skip_memo_required_check: bool = False,
-    ) -> Union[Dict[str, Any], Coroutine[Any, Any, Dict[str, Any]]]:
+    ) -> dict[str, Any] | Coroutine[Any, Any, dict[str, Any]]:
         """Submits a transaction to the network.
 
         :param transaction_envelope: :class:`stellar_sdk.transaction_envelope.TransactionEnvelope` object
@@ -68,10 +67,8 @@ class BaseServer:
 
     def _get_xdr_and_transaction_from_transaction_envelope(
         self,
-        transaction_envelope: Union[
-            TransactionEnvelope, FeeBumpTransactionEnvelope, str
-        ],
-    ) -> Tuple[str, Union[Transaction, FeeBumpTransaction]]:
+        transaction_envelope: TransactionEnvelope | FeeBumpTransactionEnvelope | str,
+    ) -> tuple[str, Transaction | FeeBumpTransaction]:
         if isinstance(transaction_envelope, BaseTransactionEnvelope):
             xdr = transaction_envelope.to_xdr()
             tx = transaction_envelope.transaction
@@ -170,9 +167,9 @@ class BaseServer:
 
     def strict_receive_paths(
         self,
-        source: Union[str, List[Asset]],
+        source: str | list[Asset],
         destination_asset: Asset,
-        destination_amount: Union[str, Decimal],
+        destination_amount: str | Decimal,
     ) -> BaseStrictReceivePathsCallBuilder:
         """
         :param source: The sender's account ID or a list of Assets. Any returned path must use a source that the sender can hold.
@@ -186,8 +183,8 @@ class BaseServer:
     def strict_send_paths(
         self,
         source_asset: Asset,
-        source_amount: Union[str, Decimal],
-        destination: Union[str, List[Asset]],
+        source_amount: str | Decimal,
+        destination: str | list[Asset],
     ) -> BaseStrictSendPathsCallBuilder:
         """
         :param source_asset: The asset to be sent.
@@ -210,9 +207,9 @@ class BaseServer:
         base: Asset,
         counter: Asset,
         resolution: int,
-        start_time: Optional[int] = None,
-        end_time: Optional[int] = None,
-        offset: Optional[int] = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
+        offset: int | None = None,
     ) -> BaseTradeAggregationsCallBuilder:
         """
         :param base: base asset
@@ -245,8 +242,8 @@ class BaseServer:
         raise NotImplementedError
 
     def load_account(
-        self, account_id: Union[MuxedAccount, Keypair, str]
-    ) -> Union[Account, Coroutine[Any, Any, Account]]:
+        self, account_id: MuxedAccount | Keypair | str
+    ) -> Account | Coroutine[Any, Any, Account]:
         """Fetches an account's most current base state (like sequence) in the ledger and then creates
         and returns an :class:`stellar_sdk.account.Account` object.
 
@@ -279,7 +276,7 @@ class BaseServer:
 
     def _get_check_memo_required_destinations(
         self, transaction: Transaction
-    ) -> Generator[Tuple[int, str], Any, Any]:
+    ) -> Generator[tuple[int, str], Any, Any]:
         destinations = set()
         for index, operation in enumerate(transaction.operations):
             if isinstance(
@@ -299,7 +296,7 @@ class BaseServer:
             destinations.add(destination)
             yield index, destination
 
-    def fetch_base_fee(self) -> Union[int, Coroutine[Any, Any, int]]:
+    def fetch_base_fee(self) -> int | Coroutine[Any, Any, int]:
         """Fetch the base fee. Since this hits the server, if the server call fails,
         you might get an error. You should be prepared to use a default value if that happens.
 
@@ -325,7 +322,7 @@ class BaseServer:
             )
         return base_fee
 
-    def close(self) -> Union[None, Coroutine[Any, Any, None]]:
+    def close(self) -> None | Coroutine[Any, Any, None]:
         """Close underlying connector.
 
         Release all acquired resources.

--- a/stellar_sdk/base_soroban_server.py
+++ b/stellar_sdk/base_soroban_server.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import copy
 import dataclasses
 import uuid
+from enum import Enum
 from typing import TYPE_CHECKING
 
 from . import xdr as stellar_xdr
 from .operation import InvokeHostFunction
 from .soroban_rpc import *
+
+if TYPE_CHECKING:
+    from .transaction_envelope import TransactionEnvelope
 
 if TYPE_CHECKING:
     from .transaction_envelope import TransactionEnvelope

--- a/stellar_sdk/base_transaction_envelope.py
+++ b/stellar_sdk/base_transaction_envelope.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
-from typing import Generic, List, Optional, Sequence, TypeVar, Union
+from collections.abc import Sequence
+from typing import Generic, TypeVar
 
 from . import xdr as stellar_xdr
 from .decorated_signature import DecoratedSignature
@@ -15,10 +16,10 @@ class BaseTransactionEnvelope(Generic[T]):
     def __init__(
         self,
         network_passphrase: str,
-        signatures: Optional[Sequence[DecoratedSignature]] = None,
+        signatures: Sequence[DecoratedSignature] | None = None,
     ) -> None:
         self.network_passphrase: str = network_passphrase
-        self.signatures: List[DecoratedSignature] = (
+        self.signatures: list[DecoratedSignature] = (
             list(signatures) if signatures else []
         )
         self._network_id: bytes = Network(network_passphrase).network_id()
@@ -42,7 +43,7 @@ class BaseTransactionEnvelope(Generic[T]):
         """
         return self.hash().hex()
 
-    def sign(self, signer: Union[Keypair, str]) -> None:
+    def sign(self, signer: Keypair | str) -> None:
         """Sign this transaction envelope with a given keypair.
 
         Note that the signature must not already be in this instance's list of
@@ -78,7 +79,7 @@ class BaseTransactionEnvelope(Generic[T]):
         """
         raise NotImplementedError("The method has not been implemented.")
 
-    def sign_hashx(self, preimage: Union[bytes, str]) -> None:
+    def sign_hashx(self, preimage: bytes | str) -> None:
         """Sign this transaction envelope with a Hash(x) signature.
 
         See Stellar's documentation on `Multi-Sig

--- a/stellar_sdk/call_builder/base/base_call_builder.py
+++ b/stellar_sdk/call_builder/base/base_call_builder.py
@@ -1,13 +1,5 @@
-from typing import (
-    Any,
-    AsyncGenerator,
-    Coroutine,
-    Dict,
-    Generator,
-    Mapping,
-    Optional,
-    Union,
-)
+from collections.abc import AsyncGenerator, Coroutine, Generator, Mapping
+from typing import Any
 
 __all__ = ["BaseCallBuilder"]
 
@@ -20,12 +12,12 @@ class BaseCallBuilder:
 
     def __init__(self, horizon_url: str) -> None:
         self.horizon_url: str = horizon_url
-        self.params: Dict[str, str] = {}
+        self.params: dict[str, str] = {}
         self.endpoint: str = ""
-        self.prev_href: Optional[str] = None
-        self.next_href: Optional[str] = None
+        self.prev_href: str | None = None
+        self.next_href: str | None = None
 
-    def call(self) -> Union[Dict[str, Any], Coroutine[Any, Any, Dict[str, Any]]]:
+    def call(self) -> dict[str, Any] | Coroutine[Any, Any, dict[str, Any]]:
         """Triggers a HTTP request using this builder's current configuration.
 
         :return: If it is called synchronous, the response will be returned. If
@@ -44,9 +36,7 @@ class BaseCallBuilder:
 
     def stream(
         self,
-    ) -> Union[
-        AsyncGenerator[Dict[str, Any], None], Generator[Dict[str, Any], None, None]
-    ]:
+    ) -> AsyncGenerator[dict[str, Any], None] | Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for incoming messages from the server.
 
         See `Horizon Response Format <https://developers.stellar.org/api/introduction/response-format/>`__
@@ -66,7 +56,7 @@ class BaseCallBuilder:
     def prev(self):
         raise NotImplementedError
 
-    def cursor(self, cursor: Union[int, str]):
+    def cursor(self, cursor: int | str):
         """Sets ``cursor`` parameter for the current call. Returns the CallBuilder object on which this method has been called.
 
         See `Pagination <https://developers.stellar.org/api/introduction/pagination/>`__
@@ -100,7 +90,7 @@ class BaseCallBuilder:
         self._add_query_param("order", order)
         return self
 
-    def _add_query_param(self, key: str, value: Union[str, float, int, bool, None]):
+    def _add_query_param(self, key: str, value: str | float | int | bool | None):
         if value is None:
             pass  # pragma: no cover
         elif value is True:
@@ -122,7 +112,7 @@ class BaseCallBuilder:
             self.next_href = next_page.get("href")
 
     def _add_query_params(
-        self, params: Mapping[str, Union[str, float, int, bool, None]]
+        self, params: Mapping[str, str | float | int | bool | None]
     ) -> None:
         for k, v in params.items():
             self._add_query_param(k, v)

--- a/stellar_sdk/call_builder/base/base_effects_call_builder.py
+++ b/stellar_sdk/call_builder/base/base_effects_call_builder.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from ...call_builder.base.base_call_builder import BaseCallBuilder
 
 __all__ = ["BaseEffectsCallBuilder"]
@@ -29,7 +27,7 @@ class BaseEffectsCallBuilder(BaseCallBuilder):
         self.endpoint = f"accounts/{account_id}/effects"
         return self
 
-    def for_ledger(self, sequence: Union[int, str]):
+    def for_ledger(self, sequence: int | str):
         """Effects are the specific ways that the ledger was changed by any operation.
         This endpoint represents all effects that occurred in the given ledger.
 
@@ -52,7 +50,7 @@ class BaseEffectsCallBuilder(BaseCallBuilder):
         self.endpoint = f"transactions/{transaction_hash}/effects"
         return self
 
-    def for_operation(self, operation_id: Union[int, str]):
+    def for_operation(self, operation_id: int | str):
         """This endpoint represents all effects that occurred as a result of a given operation.
 
         See `Retrieve an Operation's Effects <https://developers.stellar.org/api/resources/operations/effects/>`__ for more information.

--- a/stellar_sdk/call_builder/base/base_ledgers_call_builder.py
+++ b/stellar_sdk/call_builder/base/base_ledgers_call_builder.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from ...call_builder.base.base_call_builder import BaseCallBuilder
 
 __all__ = ["BaseLedgersCallBuilder"]
@@ -17,7 +15,7 @@ class BaseLedgersCallBuilder(BaseCallBuilder):
         super().__init__(horizon_url)
         self.endpoint: str = "ledgers"
 
-    def ledger(self, sequence: Union[int, str]):
+    def ledger(self, sequence: int | str):
         """Provides information on a single ledger.
 
         See `Retrieve a Ledger <https://developers.stellar.org/api/resources/ledgers/single/>`__ for more information.

--- a/stellar_sdk/call_builder/base/base_liquidity_pools_builder.py
+++ b/stellar_sdk/call_builder/base/base_liquidity_pools_builder.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from ...asset import Asset
 from ...call_builder.base.base_call_builder import BaseCallBuilder

--- a/stellar_sdk/call_builder/base/base_offers_call_builder.py
+++ b/stellar_sdk/call_builder/base/base_offers_call_builder.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from ...asset import Asset
 from ...call_builder.base.base_call_builder import BaseCallBuilder
 
@@ -85,7 +83,7 @@ class BaseOffersCallBuilder(BaseCallBuilder):
         self._add_query_params(params)
         return self
 
-    def offer(self, offer_id: Union[str, int]):
+    def offer(self, offer_id: int | str):
         """Returns information and links relating to a single offer.
 
         See `Retrieve an Offer <https://developers.stellar.org/api/resources/offers/single/>`__ for more information.

--- a/stellar_sdk/call_builder/base/base_operations_call_builder.py
+++ b/stellar_sdk/call_builder/base/base_operations_call_builder.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from ...call_builder.base.base_call_builder import BaseCallBuilder
 
 __all__ = ["BaseOperationsCallBuilder"]
@@ -17,7 +15,7 @@ class BaseOperationsCallBuilder(BaseCallBuilder):
         super().__init__(horizon_url)
         self.endpoint: str = "operations"
 
-    def operation(self, operation_id: Union[int, str]):
+    def operation(self, operation_id: int | str):
         """The operation details endpoint provides information on a single operation. The operation ID provided
         in the id argument specifies which operation to load.
 
@@ -41,7 +39,7 @@ class BaseOperationsCallBuilder(BaseCallBuilder):
         self.endpoint = f"accounts/{account_id}/operations"
         return self
 
-    def for_ledger(self, sequence: Union[int, str]):
+    def for_ledger(self, sequence: int | str):
         """This endpoint returns all operations that occurred in a given ledger.
 
         See `Retrieve a Ledger's Operations <https://developers.stellar.org/api/resources/ledgers/operations/>`__ for more information.

--- a/stellar_sdk/call_builder/base/base_payments_call_builder.py
+++ b/stellar_sdk/call_builder/base/base_payments_call_builder.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from ...call_builder.base.base_call_builder import BaseCallBuilder
 
 __all__ = ["BasePaymentsCallBuilder"]
@@ -29,7 +27,7 @@ class BasePaymentsCallBuilder(BaseCallBuilder):
         self.endpoint = f"accounts/{account_id}/payments"
         return self
 
-    def for_ledger(self, sequence: Union[int, str]):
+    def for_ledger(self, sequence: int | str):
         """This endpoint represents all payment operations that are part of a valid transactions in a given ledger.
 
         See `Retrieve a Ledger's Payments <https://developers.stellar.org/api/resources/ledgers/payments/>`__ for more information.

--- a/stellar_sdk/call_builder/base/base_strict_receive_paths_call_builder.py
+++ b/stellar_sdk/call_builder/base/base_strict_receive_paths_call_builder.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from typing import List, Union
 
 from ...asset import Asset
 from ...call_builder.base.base_call_builder import BaseCallBuilder
@@ -38,9 +37,9 @@ class BaseStrictReceivePathsCallBuilder(BaseCallBuilder):
 
     def __init__(
         self,
-        source: Union[str, List[Asset]],
+        source: str | list[Asset],
         destination_asset: Asset,
-        destination_amount: Union[str, Decimal],
+        destination_amount: str | Decimal,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/stellar_sdk/call_builder/base/base_strict_send_paths_call_builder.py
+++ b/stellar_sdk/call_builder/base/base_strict_send_paths_call_builder.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from typing import List, Union
 
 from ...asset import Asset
 from ...call_builder.base.base_call_builder import BaseCallBuilder
@@ -39,8 +38,8 @@ class BaseStrictSendPathsCallBuilder(BaseCallBuilder):
     def __init__(
         self,
         source_asset: Asset,
-        source_amount: Union[str, Decimal],
-        destination: Union[str, List[Asset]],
+        source_amount: str | Decimal,
+        destination: str | list[Asset],
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/stellar_sdk/call_builder/base/base_trades_aggregation_call_builder.py
+++ b/stellar_sdk/call_builder/base/base_trades_aggregation_call_builder.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from ...asset import Asset
 from ...call_builder.base.base_call_builder import BaseCallBuilder
 
@@ -31,9 +29,9 @@ class BaseTradeAggregationsCallBuilder(BaseCallBuilder):
         base: Asset,
         counter: Asset,
         resolution: int,
-        start_time: Optional[int] = None,
-        end_time: Optional[int] = None,
-        offset: Optional[int] = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
+        offset: int | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/stellar_sdk/call_builder/base/base_trades_call_builder.py
+++ b/stellar_sdk/call_builder/base/base_trades_call_builder.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from ...asset import Asset
 from ...call_builder.base.base_call_builder import BaseCallBuilder
 
@@ -38,7 +36,7 @@ class BaseTradesCallBuilder(BaseCallBuilder):
         self._add_query_params(params)
         return self
 
-    def for_offer(self, offer_id: Union[int, str]):
+    def for_offer(self, offer_id: int | str):
         """Filter trades for a specific offer
 
         See `List All Trades <https://developers.stellar.org/api/resources/trades/list/>`__ for more information.

--- a/stellar_sdk/call_builder/base/base_transactions_call_builder.py
+++ b/stellar_sdk/call_builder/base/base_transactions_call_builder.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from ...call_builder.base.base_call_builder import BaseCallBuilder
 
 __all__ = ["BaseTransactionsCallBuilder"]
@@ -41,7 +39,7 @@ class BaseTransactionsCallBuilder(BaseCallBuilder):
         self.endpoint = f"accounts/{account_id}/transactions"
         return self
 
-    def for_ledger(self, sequence: Union[str, int]):
+    def for_ledger(self, sequence: int | str):
         """This endpoint represents all transactions in a given ledger.
 
         See `Retrieve a Ledger's Transactions <https://developers.stellar.org/api/resources/ledgers/transactions/>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_async/accounts_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_async/accounts_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncGenerator, Dict
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from ...call_builder.base.base_accounts_call_builder import BaseAccountsCallBuilder
 from ...call_builder.call_builder_async.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class AccountsCallBuilder(BaseCallBuilder, BaseAccountsCallBuilder):
 
     def stream(
         self,
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Creates an EventSource that listens for events from the `Accounts` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_async/base_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_async/base_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncGenerator, Dict, Optional
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from ...call_builder.base.base_call_builder import BaseCallBuilder as _BaseCallBuilder
 from ...client.base_async_client import BaseAsyncClient
@@ -22,7 +23,7 @@ class BaseCallBuilder(_BaseCallBuilder):
         super().__init__(**kwargs)
         self.client: BaseAsyncClient = client
 
-    async def call(self) -> Dict[str, Any]:
+    async def call(self) -> dict[str, Any]:
         """Triggers a HTTP request using this builder's current configuration.
 
         :return: If it is called synchronous, the response will be returned. If
@@ -40,7 +41,7 @@ class BaseCallBuilder(_BaseCallBuilder):
         url = urljoin_with_query(self.horizon_url, self.endpoint)
         return await self._call(url, self.params)
 
-    async def _call(self, url: str, params: Optional[dict] = None) -> Dict[str, Any]:
+    async def _call(self, url: str, params: dict | None = None) -> dict[str, Any]:
         raw_resp = await self.client.get(url, params)
         assert isinstance(raw_resp, Response)
         raise_request_exception(raw_resp)
@@ -50,7 +51,7 @@ class BaseCallBuilder(_BaseCallBuilder):
 
     async def _stream(
         self,
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Creates an EventSource that listens for incoming messages from the server.
 
         See `Horizon Response Format <https://developers.stellar.org/api/introduction/response-format/>`__
@@ -62,18 +63,18 @@ class BaseCallBuilder(_BaseCallBuilder):
         :raise: :exc:`StreamClientError <stellar_sdk.exceptions.StreamClientError>` - Failed to fetch stream resource.
         """
         url = urljoin_with_query(self.horizon_url, self.endpoint)
-        stream: AsyncGenerator[Dict[str, Any], None] = self.client.stream(
+        stream: AsyncGenerator[dict[str, Any], None] = self.client.stream(
             url, self.params
         )
         while True:
             yield await stream.__anext__()
 
-    async def next(self) -> Dict[str, Any]:
+    async def next(self) -> dict[str, Any]:
         if self.next_href is None:
             raise NotPageableError("The next page does not exist.")
         return await self._call(self.next_href, None)
 
-    async def prev(self) -> Dict[str, Any]:
+    async def prev(self) -> dict[str, Any]:
         if self.prev_href is None:
             raise NotPageableError("The prev page does not exist.")
         return await self._call(self.prev_href, None)

--- a/stellar_sdk/call_builder/call_builder_async/data_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_async/data_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncGenerator, Dict
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from ...call_builder.base import BaseDataCallBuilder
 from ...call_builder.call_builder_async.base_call_builder import BaseCallBuilder
@@ -35,7 +36,7 @@ class DataCallBuilder(BaseCallBuilder, BaseDataCallBuilder):
 
     def stream(
         self,
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Creates an EventSource that listens for events from the `Account Data` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_async/effects_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_async/effects_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncGenerator, Dict
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from ...call_builder.base import BaseEffectsCallBuilder
 from ...call_builder.call_builder_async.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class EffectsCallBuilder(BaseCallBuilder, BaseEffectsCallBuilder):
 
     def stream(
         self,
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Creates an EventSource that listens for events from the `Effects` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_async/ledgers_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_async/ledgers_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncGenerator, Dict
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from ...call_builder.base import BaseLedgersCallBuilder
 from ...call_builder.call_builder_async.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class LedgersCallBuilder(BaseCallBuilder, BaseLedgersCallBuilder):
 
     def stream(
         self,
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Creates an EventSource that listens for events from the `Ledgers` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_async/operations_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_async/operations_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncGenerator, Dict
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from ...call_builder.base import BaseOperationsCallBuilder
 from ...call_builder.call_builder_async.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class OperationsCallBuilder(BaseCallBuilder, BaseOperationsCallBuilder):
 
     def stream(
         self,
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Creates an EventSource that listens for events from the `Operations` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_async/orderbook_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_async/orderbook_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncGenerator, Dict
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from ...asset import Asset
 from ...call_builder.base import BaseOrderbookCallBuilder
@@ -33,7 +34,7 @@ class OrderbookCallBuilder(BaseCallBuilder, BaseOrderbookCallBuilder):
 
     def stream(
         self,
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Creates an EventSource that listens for events from the `Orderbook` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_async/payments_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_async/payments_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncGenerator, Dict
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from ...call_builder.base import BasePaymentsCallBuilder
 from ...call_builder.call_builder_async.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class PaymentsCallBuilder(BaseCallBuilder, BasePaymentsCallBuilder):
 
     def stream(
         self,
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Creates an EventSource that listens for events from the `Payments` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_async/strict_receive_paths_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_async/strict_receive_paths_call_builder.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from typing import List, Union
 
 from ...asset import Asset
 from ...call_builder.base import BaseStrictReceivePathsCallBuilder
@@ -43,9 +42,9 @@ class StrictReceivePathsCallBuilder(BaseCallBuilder, BaseStrictReceivePathsCallB
         self,
         horizon_url: str,
         client: BaseAsyncClient,
-        source: Union[str, List[Asset]],
+        source: str | list[Asset],
         destination_asset: Asset,
-        destination_amount: Union[str, Decimal],
+        destination_amount: str | Decimal,
     ) -> None:
         super().__init__(
             horizon_url=horizon_url,

--- a/stellar_sdk/call_builder/call_builder_async/strict_send_paths_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_async/strict_send_paths_call_builder.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from typing import List, Union
 
 from ...asset import Asset
 from ...call_builder.base import BaseStrictSendPathsCallBuilder
@@ -44,8 +43,8 @@ class StrictSendPathsCallBuilder(BaseCallBuilder, BaseStrictSendPathsCallBuilder
         horizon_url: str,
         client: BaseAsyncClient,
         source_asset: Asset,
-        source_amount: Union[str, Decimal],
-        destination: Union[str, List[Asset]],
+        source_amount: str | Decimal,
+        destination: str | list[Asset],
     ) -> None:
         super().__init__(
             horizon_url=horizon_url,

--- a/stellar_sdk/call_builder/call_builder_async/trades_aggregation_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_async/trades_aggregation_call_builder.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from ...asset import Asset
 from ...call_builder.base import BaseTradeAggregationsCallBuilder
 from ...call_builder.call_builder_async.base_call_builder import BaseCallBuilder
@@ -37,9 +35,9 @@ class TradeAggregationsCallBuilder(BaseCallBuilder, BaseTradeAggregationsCallBui
         base: Asset,
         counter: Asset,
         resolution: int,
-        start_time: Optional[int] = None,
-        end_time: Optional[int] = None,
-        offset: Optional[int] = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
+        offset: int | None = None,
     ) -> None:
         super().__init__(
             horizon_url=horizon_url,

--- a/stellar_sdk/call_builder/call_builder_async/trades_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_async/trades_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncGenerator, Dict
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from ...call_builder.base import BaseTradesCallBuilder
 from ...call_builder.call_builder_async.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class TradesCallBuilder(BaseCallBuilder, BaseTradesCallBuilder):
 
     def stream(
         self,
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Creates an EventSource that listens for events from the `Trades` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_async/transactions_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_async/transactions_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncGenerator, Dict
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from ...call_builder.base import BaseTransactionsCallBuilder
 from ...call_builder.call_builder_async.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class TransactionsCallBuilder(BaseCallBuilder, BaseTransactionsCallBuilder):
 
     def stream(
         self,
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Creates an EventSource that listens for events from the `Transactions` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_sync/accounts_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/accounts_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Generator
+from collections.abc import Generator
+from typing import Any
 
 from ...call_builder.base.base_accounts_call_builder import BaseAccountsCallBuilder
 from ...call_builder.call_builder_sync.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class AccountsCallBuilder(BaseCallBuilder, BaseAccountsCallBuilder):
 
     def stream(
         self,
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for events from the `Accounts` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_sync/base_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/base_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Generator, Optional
+from collections.abc import Generator
+from typing import Any
 
 from ...call_builder.base.base_call_builder import BaseCallBuilder as _BaseCallBuilder
 from ...client.base_sync_client import BaseSyncClient
@@ -22,7 +23,7 @@ class BaseCallBuilder(_BaseCallBuilder):
         super().__init__(**kwargs)
         self.client: BaseSyncClient = client
 
-    def call(self) -> Dict[str, Any]:
+    def call(self) -> dict[str, Any]:
         """Triggers a HTTP request using this builder's current configuration.
 
         :return: If it is called synchronous, the response will be returned. If
@@ -40,7 +41,7 @@ class BaseCallBuilder(_BaseCallBuilder):
         url = urljoin_with_query(self.horizon_url, self.endpoint)
         return self._call(url, self.params)
 
-    def _call(self, url: str, params: Optional[dict] = None) -> Dict[str, Any]:
+    def _call(self, url: str, params: dict | None = None) -> dict[str, Any]:
         raw_resp = self.client.get(url, params)
         assert isinstance(raw_resp, Response)
         raise_request_exception(raw_resp)
@@ -50,7 +51,7 @@ class BaseCallBuilder(_BaseCallBuilder):
 
     def _stream(
         self,
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for incoming messages from the server.
 
         See `Horizon Response Format <https://developers.stellar.org/api/introduction/response-format/>`__
@@ -64,12 +65,12 @@ class BaseCallBuilder(_BaseCallBuilder):
         url = urljoin_with_query(self.horizon_url, self.endpoint)
         return self.client.stream(url, self.params)
 
-    def next(self) -> Dict[str, Any]:
+    def next(self) -> dict[str, Any]:
         if self.next_href is None:
             raise NotPageableError("The next page does not exist.")
         return self._call(self.next_href, None)
 
-    def prev(self) -> Dict[str, Any]:
+    def prev(self) -> dict[str, Any]:
         if self.prev_href is None:
             raise NotPageableError("The prev page does not exist.")
         return self._call(self.prev_href, None)

--- a/stellar_sdk/call_builder/call_builder_sync/data_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/data_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Generator
+from collections.abc import Generator
+from typing import Any
 
 from ...call_builder.base import BaseDataCallBuilder
 from ...call_builder.call_builder_sync.base_call_builder import BaseCallBuilder
@@ -35,7 +36,7 @@ class DataCallBuilder(BaseCallBuilder, BaseDataCallBuilder):
 
     def stream(
         self,
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for events from the `Account Data` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_sync/effects_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/effects_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Generator
+from collections.abc import Generator
+from typing import Any
 
 from ...call_builder.base import BaseEffectsCallBuilder
 from ...call_builder.call_builder_sync.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class EffectsCallBuilder(BaseCallBuilder, BaseEffectsCallBuilder):
 
     def stream(
         self,
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for events from the `Effects` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_sync/ledgers_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/ledgers_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Generator
+from collections.abc import Generator
+from typing import Any
 
 from ...call_builder.base import BaseLedgersCallBuilder
 from ...call_builder.call_builder_sync.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class LedgersCallBuilder(BaseCallBuilder, BaseLedgersCallBuilder):
 
     def stream(
         self,
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for events from the `Ledgers` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_sync/offers_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/offers_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Generator
+from collections.abc import Generator
+from typing import Any
 
 from ...call_builder.base import BaseOffersCallBuilder
 from ...call_builder.call_builder_sync.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class OffersCallBuilder(BaseCallBuilder, BaseOffersCallBuilder):
 
     def stream(
         self,
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for events from the `Offers` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_sync/operations_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/operations_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Generator
+from collections.abc import Generator
+from typing import Any
 
 from ...call_builder.base import BaseOperationsCallBuilder
 from ...call_builder.call_builder_sync.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class OperationsCallBuilder(BaseCallBuilder, BaseOperationsCallBuilder):
 
     def stream(
         self,
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for events from the `Operations` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_sync/orderbook_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/orderbook_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Generator
+from collections.abc import Generator
+from typing import Any
 
 from ...asset import Asset
 from ...call_builder.base import BaseOrderbookCallBuilder
@@ -33,7 +34,7 @@ class OrderbookCallBuilder(BaseCallBuilder, BaseOrderbookCallBuilder):
 
     def stream(
         self,
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for events from the `Orderbook` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_sync/payments_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/payments_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Generator
+from collections.abc import Generator
+from typing import Any
 
 from ...call_builder.base import BasePaymentsCallBuilder
 from ...call_builder.call_builder_sync.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class PaymentsCallBuilder(BaseCallBuilder, BasePaymentsCallBuilder):
 
     def stream(
         self,
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for events from the `Payments` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_sync/strict_receive_paths_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/strict_receive_paths_call_builder.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from typing import List, Union
 
 from ...asset import Asset
 from ...call_builder.base import BaseStrictReceivePathsCallBuilder
@@ -43,9 +42,9 @@ class StrictReceivePathsCallBuilder(BaseCallBuilder, BaseStrictReceivePathsCallB
         self,
         horizon_url: str,
         client: BaseSyncClient,
-        source: Union[str, List[Asset]],
+        source: str | list[Asset],
         destination_asset: Asset,
-        destination_amount: Union[str, Decimal],
+        destination_amount: str | Decimal,
     ) -> None:
         super().__init__(
             horizon_url=horizon_url,

--- a/stellar_sdk/call_builder/call_builder_sync/strict_send_paths_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/strict_send_paths_call_builder.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from typing import List, Union
 
 from ...asset import Asset
 from ...call_builder.base import BaseStrictSendPathsCallBuilder
@@ -44,8 +43,8 @@ class StrictSendPathsCallBuilder(BaseCallBuilder, BaseStrictSendPathsCallBuilder
         horizon_url: str,
         client: BaseSyncClient,
         source_asset: Asset,
-        source_amount: Union[str, Decimal],
-        destination: Union[str, List[Asset]],
+        source_amount: str | Decimal,
+        destination: str | list[Asset],
     ) -> None:
         super().__init__(
             horizon_url=horizon_url,

--- a/stellar_sdk/call_builder/call_builder_sync/trades_aggregation_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/trades_aggregation_call_builder.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from ...asset import Asset
 from ...call_builder.base import BaseTradeAggregationsCallBuilder
 from ...call_builder.call_builder_sync.base_call_builder import BaseCallBuilder
@@ -37,9 +35,9 @@ class TradeAggregationsCallBuilder(BaseCallBuilder, BaseTradeAggregationsCallBui
         base: Asset,
         counter: Asset,
         resolution: int,
-        start_time: Optional[int] = None,
-        end_time: Optional[int] = None,
-        offset: Optional[int] = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
+        offset: int | None = None,
     ) -> None:
         super().__init__(
             horizon_url=horizon_url,

--- a/stellar_sdk/call_builder/call_builder_sync/trades_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/trades_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Generator
+from collections.abc import Generator
+from typing import Any
 
 from ...call_builder.base import BaseTradesCallBuilder
 from ...call_builder.call_builder_sync.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class TradesCallBuilder(BaseCallBuilder, BaseTradesCallBuilder):
 
     def stream(
         self,
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for events from the `Trades` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/call_builder/call_builder_sync/transactions_call_builder.py
+++ b/stellar_sdk/call_builder/call_builder_sync/transactions_call_builder.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Generator
+from collections.abc import Generator
+from typing import Any
 
 from ...call_builder.base import BaseTransactionsCallBuilder
 from ...call_builder.call_builder_sync.base_call_builder import BaseCallBuilder
@@ -22,7 +23,7 @@ class TransactionsCallBuilder(BaseCallBuilder, BaseTransactionsCallBuilder):
 
     def stream(
         self,
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for events from the `Transactions` endpoint.
 
         See `Streaming <https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming>`__ for more information.

--- a/stellar_sdk/client/aiohttp_client.py
+++ b/stellar_sdk/client/aiohttp_client.py
@@ -2,7 +2,8 @@
 import asyncio
 import json
 import logging
-from typing import Any, AsyncGenerator, Dict, Optional
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from ..__version__ import __version__
 from ..exceptions import ConnectionError, StreamClientError
@@ -80,12 +81,12 @@ class AiohttpClient(BaseAsyncClient):
 
     def __init__(
         self,
-        pool_size: Optional[int] = None,
+        pool_size: int | None = None,
         request_timeout: float = defines.DEFAULT_GET_TIMEOUT_SECONDS,
         post_timeout: float = defines.DEFAULT_POST_TIMEOUT_SECONDS,
-        backoff_factor: Optional[float] = DEFAULT_BACKOFF_FACTOR,
-        user_agent: Optional[str] = None,
-        custom_headers: Optional[Dict[str, str]] = None,
+        backoff_factor: float | None = DEFAULT_BACKOFF_FACTOR,
+        user_agent: str | None = None,
+        custom_headers: dict[str, str] | None = None,
         **kwargs,
     ) -> None:
         if not _AIOHTTP_DEPS_INSTALLED:
@@ -94,12 +95,12 @@ class AiohttpClient(BaseAsyncClient):
                 "Please install `stellar-sdk[aiohttp]` to use this feature."
             )
         self.pool_size = pool_size
-        self.backoff_factor: Optional[float] = backoff_factor
+        self.backoff_factor: float | None = backoff_factor
         self.request_timeout: float = request_timeout
         self.post_timeout: float = post_timeout
         self.__kwargs = kwargs
 
-        self.user_agent: Optional[str] = USER_AGENT
+        self.user_agent: str | None = USER_AGENT
         if user_agent:
             self.user_agent = user_agent
 
@@ -111,10 +112,10 @@ class AiohttpClient(BaseAsyncClient):
         if custom_headers:
             self.headers = {**self.headers, **custom_headers}
 
-        self._session: Optional[aiohttp.ClientSession] = None
-        self._sse_session: Optional[aiohttp.ClientSession] = None
+        self._session: aiohttp.ClientSession | None = None
+        self._sse_session: aiohttp.ClientSession | None = None
 
-    async def get(self, url: str, params: Optional[Dict[str, str]] = None) -> Response:
+    async def get(self, url: str, params: dict[str, str] | None = None) -> Response:
         """Perform HTTP GET request.
 
         :param url: the request url
@@ -138,8 +139,8 @@ class AiohttpClient(BaseAsyncClient):
     async def post(
         self,
         url: str,
-        data: Optional[Dict[str, str]] = None,
-        json_data: Optional[Dict[str, Any]] = None,
+        data: dict[str, str] | None = None,
+        json_data: dict[str, Any] | None = None,
     ) -> Response:
         """Perform HTTP POST request.
 
@@ -168,8 +169,8 @@ class AiohttpClient(BaseAsyncClient):
             raise ConnectionError(e)
 
     async def stream(
-        self, url: str, params: Optional[Dict[str, str]] = None
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+        self, url: str, params: dict[str, str] | None = None
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Perform Stream request.
 
         :param url: the request url

--- a/stellar_sdk/client/base_async_client.py
+++ b/stellar_sdk/client/base_async_client.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, AsyncGenerator, Dict, Optional
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from .response import Response
 
@@ -13,7 +14,7 @@ class BaseAsyncClient(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    async def get(self, url: str, params: Optional[Dict[str, str]] = None) -> Response:
+    async def get(self, url: str, params: dict[str, str] | None = None) -> Response:
         """Perform HTTP GET request.
 
         :param url: the request url
@@ -27,8 +28,8 @@ class BaseAsyncClient(metaclass=ABCMeta):
     async def post(
         self,
         url: str,
-        data: Optional[Dict[str, str]] = None,
-        json_data: Optional[Dict[str, Any]] = None,
+        data: dict[str, str] | None = None,
+        json_data: dict[str, Any] | None = None,
     ) -> Response:
         """Perform HTTP POST request.
 
@@ -42,8 +43,8 @@ class BaseAsyncClient(metaclass=ABCMeta):
 
     @abstractmethod
     def stream(
-        self, url: str, params: Optional[Dict[str, str]] = None
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+        self, url: str, params: dict[str, str] | None = None
+    ) -> AsyncGenerator[dict[str, Any], None]:
         """Creates an EventSource that listens for incoming messages from the server.
 
         See `Horizon Response Format <https://developers.stellar.org/api/introduction/response-format/>`__

--- a/stellar_sdk/client/base_sync_client.py
+++ b/stellar_sdk/client/base_sync_client.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, Dict, Generator, Optional
+from collections.abc import Generator
+from typing import Any
 
 from .response import Response
 
@@ -13,7 +14,7 @@ class BaseSyncClient(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def get(self, url: str, params: Optional[Dict[str, str]] = None) -> Response:
+    def get(self, url: str, params: dict[str, str] | None = None) -> Response:
         """Perform HTTP GET request.
 
         :param url: the request url
@@ -26,8 +27,8 @@ class BaseSyncClient(metaclass=ABCMeta):
     def post(
         self,
         url: str,
-        data: Optional[Dict[str, str]] = None,
-        json_data: Optional[Dict[str, Any]] = None,
+        data: dict[str, str] | None = None,
+        json_data: dict[str, Any] | None = None,
     ) -> Response:
         """Perform HTTP POST request.
 
@@ -40,8 +41,8 @@ class BaseSyncClient(metaclass=ABCMeta):
 
     @abstractmethod
     def stream(
-        self, url: str, params: Optional[Dict[str, str]] = None
-    ) -> Generator[Dict[str, Any], None, None]:
+        self, url: str, params: dict[str, str] | None = None
+    ) -> Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for incoming messages from the server.
 
         See `Horizon Response Format <https://developers.stellar.org/api/introduction/response-format/>`__

--- a/stellar_sdk/client/requests_client.py
+++ b/stellar_sdk/client/requests_client.py
@@ -1,7 +1,8 @@
 import json
 import logging
 import time
-from typing import Any, Dict, Generator, Optional
+from collections.abc import Generator
+from typing import Any
 
 import requests
 from requests import RequestException, Session
@@ -50,9 +51,9 @@ class RequestsClient(BaseSyncClient):
         request_timeout: int = defines.DEFAULT_GET_TIMEOUT_SECONDS,
         post_timeout: float = defines.DEFAULT_POST_TIMEOUT_SECONDS,
         backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
-        session: Optional[Session] = None,
-        stream_session: Optional[Session] = None,
-        custom_headers: Optional[Dict[str, str]] = None,
+        session: Session | None = None,
+        stream_session: Session | None = None,
+        custom_headers: dict[str, str] | None = None,
     ):
         self.pool_size: int = pool_size
         self.num_retries: int = num_retries
@@ -96,9 +97,9 @@ class RequestsClient(BaseSyncClient):
             session.mount("http://", adapter)
             session.mount("https://", adapter)
         self._session: Session = session
-        self._stream_session: Optional[Session] = stream_session
+        self._stream_session: Session | None = stream_session
 
-    def get(self, url: str, params: Optional[Dict[str, str]] = None) -> Response:
+    def get(self, url: str, params: dict[str, str] | None = None) -> Response:
         """Perform HTTP GET request.
 
         :param url: the request url
@@ -120,8 +121,8 @@ class RequestsClient(BaseSyncClient):
     def post(
         self,
         url: str,
-        data: Optional[Dict[str, str]] = None,
-        json_data: Optional[Dict[str, Any]] = None,
+        data: dict[str, str] | None = None,
+        json_data: dict[str, Any] | None = None,
     ) -> Response:
         """Perform HTTP POST request.
 
@@ -145,8 +146,8 @@ class RequestsClient(BaseSyncClient):
         )
 
     def stream(
-        self, url: str, params: Optional[Dict[str, str]] = None
-    ) -> Generator[Dict[str, Any], None, None]:
+        self, url: str, params: dict[str, str] | None = None
+    ) -> Generator[dict[str, Any], None, None]:
         """Creates an EventSource that listens for incoming messages from the server.
 
         See `Horizon Response Format <https://developers.stellar.org/api/introduction/response-format/>`__

--- a/stellar_sdk/client/simple_requests_client.py
+++ b/stellar_sdk/client/simple_requests_client.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Generator, Optional
+from collections.abc import Generator
+from typing import Any
 
 import requests
 from requests import RequestException
@@ -26,7 +27,7 @@ class SimpleRequestsClient(BaseSyncClient):
     I don't recommend that you actually use it.**
     """
 
-    def get(self, url: str, params: Optional[Dict[str, str]] = None) -> Response:
+    def get(self, url: str, params: dict[str, str] | None = None) -> Response:
         """Perform HTTP GET request.
 
         :param url: the request url
@@ -48,8 +49,8 @@ class SimpleRequestsClient(BaseSyncClient):
     def post(
         self,
         url: str,
-        data: Optional[Dict[str, str]] = None,
-        json_data: Optional[Dict[str, Any]] = None,
+        data: dict[str, str] | None = None,
+        json_data: dict[str, Any] | None = None,
     ) -> Response:
         """Perform HTTP POST request.
 
@@ -71,8 +72,8 @@ class SimpleRequestsClient(BaseSyncClient):
         )
 
     def stream(
-        self, url: str, params: Optional[Dict[str, str]] = None
-    ) -> Generator[Dict[str, Any], None, None]:
+        self, url: str, params: dict[str, str] | None = None
+    ) -> Generator[dict[str, Any], None, None]:
         """
         **Not Implemented**
 

--- a/stellar_sdk/contract/assembled_transaction.py
+++ b/stellar_sdk/contract/assembled_transaction.py
@@ -1,6 +1,6 @@
 import dataclasses
 import time
-from typing import Callable, Generic, Optional, Set, TypeVar, Union
+from typing import Callable, Generic, TypeVar
 
 from .. import Address, Keypair, SorobanDataBuilder, xdr
 from ..auth import authorize_entry
@@ -46,8 +46,8 @@ class AssembledTransaction(Generic[T]):
         self,
         transaction_builder: TransactionBuilder,
         server: SorobanServer,
-        transaction_signer: Optional[Keypair] = None,
-        parse_result_xdr_fn: Optional[Callable[[xdr.SCVal], T]] = None,
+        transaction_signer: Keypair | None = None,
+        parse_result_xdr_fn: Callable[[xdr.SCVal], T] | None = None,
         submit_timeout: int = 180,
     ):
         self.server = server
@@ -57,14 +57,14 @@ class AssembledTransaction(Generic[T]):
         self.parse_result_xdr_fn = parse_result_xdr_fn
 
         self.transaction_builder: TransactionBuilder = transaction_builder
-        self.built_transaction: Optional[TransactionEnvelope] = None
+        self.built_transaction: TransactionEnvelope | None = None
 
-        self.simulation: Optional[SimulateTransactionResponse] = None
-        self._simulation_result: Optional[SimulateHostFunctionResult] = None
-        self._simulation_transaction_data: Optional[xdr.SorobanTransactionData] = None
+        self.simulation: SimulateTransactionResponse | None = None
+        self._simulation_result: SimulateHostFunctionResult | None = None
+        self._simulation_transaction_data: xdr.SorobanTransactionData | None = None
 
-        self.send_transaction_response: Optional[SendTransactionResponse] = None
-        self.get_transaction_response: Optional[GetTransactionResponse] = None
+        self.send_transaction_response: SendTransactionResponse | None = None
+        self.get_transaction_response: GetTransactionResponse | None = None
 
     def simulate(self, restore: bool = True) -> "AssembledTransaction":
         """Simulates the transaction on the network.
@@ -110,8 +110,8 @@ class AssembledTransaction(Generic[T]):
         return self
 
     def sign_and_submit(
-        self, transaction_signer: Optional[Keypair] = None, force: bool = False
-    ) -> Union[T, xdr.SCVal]:
+        self, transaction_signer: Keypair | None = None, force: bool = False
+    ) -> T | xdr.SCVal:
         """Signs and submits the transaction in one step.
 
         A convenience method combining sign() and submit().
@@ -124,7 +124,7 @@ class AssembledTransaction(Generic[T]):
         return self.submit()
 
     def sign(
-        self, transaction_signer: Optional[Keypair] = None, force: bool = False
+        self, transaction_signer: Keypair | None = None, force: bool = False
     ) -> "AssembledTransaction":
         """Signs the transaction.
 
@@ -173,7 +173,7 @@ class AssembledTransaction(Generic[T]):
     def sign_auth_entries(
         self,
         auth_entries_signer: Keypair,
-        valid_until_ledger_sequence: Optional[int] = None,
+        valid_until_ledger_sequence: int | None = None,
     ) -> "AssembledTransaction":
         """Signs the transaction's authorization entries.
 
@@ -210,7 +210,7 @@ class AssembledTransaction(Generic[T]):
             )
         return self
 
-    def submit(self) -> Union[T, xdr.SCVal]:
+    def submit(self) -> T | xdr.SCVal:
         """Submits the transaction to the network.
 
         It will send the transaction to the network and wait for the result.
@@ -276,7 +276,7 @@ class AssembledTransaction(Generic[T]):
 
     def needs_non_invoker_signing_by(
         self, include_already_signed: bool = False
-    ) -> Set[str]:
+    ) -> set[str]:
         """Get the addresses that need to sign the authorization entries.
 
         :param include_already_signed: Whether to include addresses that have already signed the authorization entries.
@@ -309,7 +309,7 @@ class AssembledTransaction(Generic[T]):
                     result.add(address)
         return result
 
-    def result(self) -> Union[T, xdr.SCVal]:
+    def result(self) -> T | xdr.SCVal:
         """Get the result of the function invocation from the simulation.
 
         :return: The value returned by the invoked function, parsed if parse_result_xdr_fn was set, otherwise raw XDR

--- a/stellar_sdk/contract/assembled_transaction_async.py
+++ b/stellar_sdk/contract/assembled_transaction_async.py
@@ -1,7 +1,7 @@
 import asyncio
 import dataclasses
 import time
-from typing import Callable, Generic, Optional, Set, TypeVar, Union
+from typing import Callable, Generic, TypeVar
 
 from .. import Address, Keypair, SorobanDataBuilder, SorobanServerAsync, xdr
 from ..auth import authorize_entry
@@ -46,8 +46,8 @@ class AssembledTransactionAsync(Generic[T]):
         self,
         transaction_builder: TransactionBuilder,
         server: SorobanServerAsync,
-        transaction_signer: Optional[Keypair] = None,
-        parse_result_xdr_fn: Optional[Callable[[xdr.SCVal], T]] = None,
+        transaction_signer: Keypair | None = None,
+        parse_result_xdr_fn: Callable[[xdr.SCVal], T] | None = None,
         submit_timeout: int = 180,
     ):
         self.server = server
@@ -57,14 +57,14 @@ class AssembledTransactionAsync(Generic[T]):
         self.parse_result_xdr_fn = parse_result_xdr_fn
 
         self.transaction_builder: TransactionBuilder = transaction_builder
-        self.built_transaction: Optional[TransactionEnvelope] = None
+        self.built_transaction: TransactionEnvelope | None = None
 
-        self.simulation: Optional[SimulateTransactionResponse] = None
-        self._simulation_result: Optional[SimulateHostFunctionResult] = None
-        self._simulation_transaction_data: Optional[xdr.SorobanTransactionData] = None
+        self.simulation: SimulateTransactionResponse | None = None
+        self._simulation_result: SimulateHostFunctionResult | None = None
+        self._simulation_transaction_data: xdr.SorobanTransactionData | None = None
 
-        self.send_transaction_response: Optional[SendTransactionResponse] = None
-        self.get_transaction_response: Optional[GetTransactionResponse] = None
+        self.send_transaction_response: SendTransactionResponse | None = None
+        self.get_transaction_response: GetTransactionResponse | None = None
 
     async def simulate(self, restore: bool = True) -> "AssembledTransactionAsync":
         """Simulates the transaction on the network.
@@ -110,8 +110,8 @@ class AssembledTransactionAsync(Generic[T]):
         return self
 
     async def sign_and_submit(
-        self, transaction_signer: Optional[Keypair] = None, force: bool = False
-    ) -> Union[T, xdr.SCVal]:
+        self, transaction_signer: Keypair | None = None, force: bool = False
+    ) -> T | xdr.SCVal:
         """Signs and submits the transaction in one step.
 
         A convenience method combining sign() and submit().
@@ -124,7 +124,7 @@ class AssembledTransactionAsync(Generic[T]):
         return await self.submit()
 
     def sign(
-        self, transaction_signer: Optional[Keypair] = None, force: bool = False
+        self, transaction_signer: Keypair | None = None, force: bool = False
     ) -> "AssembledTransactionAsync":
         """Signs the transaction.
 
@@ -173,7 +173,7 @@ class AssembledTransactionAsync(Generic[T]):
     async def sign_auth_entries(
         self,
         auth_entries_signer: Keypair,
-        valid_until_ledger_sequence: Optional[int] = None,
+        valid_until_ledger_sequence: int | None = None,
     ) -> "AssembledTransactionAsync":
         """Signs the transaction's authorization entries.
 
@@ -212,7 +212,7 @@ class AssembledTransactionAsync(Generic[T]):
             )
         return self
 
-    async def submit(self) -> Union[T, xdr.SCVal]:
+    async def submit(self) -> T | xdr.SCVal:
         """Submits the transaction to the network.
 
         It will send the transaction to the network and wait for the result.
@@ -280,7 +280,7 @@ class AssembledTransactionAsync(Generic[T]):
 
     def needs_non_invoker_signing_by(
         self, include_already_signed: bool = False
-    ) -> Set[str]:
+    ) -> set[str]:
         """Get the addresses that need to sign the authorization entries.
 
         :param include_already_signed: Whether to include addresses that have already signed the authorization entries.
@@ -313,7 +313,7 @@ class AssembledTransactionAsync(Generic[T]):
                     result.add(address)
         return result
 
-    def result(self) -> Union[T, xdr.SCVal]:
+    def result(self) -> T | xdr.SCVal:
         """Get the result of the function invocation from the simulation.
 
         :return: The value returned by the invoked function, parsed if parse_result_xdr_fn was set, otherwise raw XDR

--- a/stellar_sdk/contract/contract_client.py
+++ b/stellar_sdk/contract/contract_client.py
@@ -1,4 +1,5 @@
-from typing import Callable, Optional, Sequence, TypeVar, Union
+from collections.abc import Sequence
+from typing import Callable, TypeVar
 
 from .. import Account, Asset, Keypair, MuxedAccount, scval
 from .. import xdr as stellar_xdr
@@ -34,7 +35,7 @@ class ContractClient:
         contract_id: str,
         rpc_url: str,
         network_passphrase: str,
-        request_client: Optional[BaseSyncClient] = None,
+        request_client: BaseSyncClient | None = None,
     ):
         self.contract_id = contract_id
         self.rpc_url = rpc_url
@@ -44,10 +45,10 @@ class ContractClient:
     def invoke(
         self,
         function_name: str,
-        parameters: Optional[Sequence[stellar_xdr.SCVal]] = None,
-        source: Union[str, MuxedAccount] = NULL_ACCOUNT,
-        signer: Optional[Keypair] = None,
-        parse_result_xdr_fn: Optional[Callable[[stellar_xdr.SCVal], T]] = None,
+        parameters: Sequence[stellar_xdr.SCVal] | None = None,
+        source: str | MuxedAccount = NULL_ACCOUNT,
+        signer: Keypair | None = None,
+        parse_result_xdr_fn: Callable[[stellar_xdr.SCVal], T] | None = None,
         base_fee: int = 100,
         transaction_timeout: int = 300,
         submit_timeout: int = 30,
@@ -86,11 +87,11 @@ class ContractClient:
 
     @staticmethod
     def upload_contract_wasm(
-        contract: Union[bytes, str],
-        source: Union[str, MuxedAccount],
+        contract: bytes | str,
+        source: str | MuxedAccount,
         signer: Keypair,
         soroban_server: SorobanServer,
-        network_passphrase: Optional[str] = None,
+        network_passphrase: str | None = None,
         base_fee: int = 100,
         transaction_timeout: int = 300,
         submit_timeout: int = 120,
@@ -132,13 +133,13 @@ class ContractClient:
 
     @staticmethod
     def create_contract(
-        wasm_id: Union[bytes, str],
-        source: Union[str, MuxedAccount],
+        wasm_id: bytes | str,
+        source: str | MuxedAccount,
         signer: Keypair,
         soroban_server: SorobanServer,
-        constructor_args: Optional[Sequence[stellar_xdr.SCVal]] = None,
-        salt: Optional[bytes] = None,
-        network_passphrase: Optional[str] = None,
+        constructor_args: Sequence[stellar_xdr.SCVal] | None = None,
+        salt: bytes | None = None,
+        network_passphrase: str | None = None,
         base_fee: int = 100,
         transaction_timeout: int = 300,
         submit_timeout: int = 120,
@@ -186,10 +187,10 @@ class ContractClient:
     @staticmethod
     def create_stellar_asset_contract_from_asset(
         asset: Asset,
-        source: Union[str, MuxedAccount],
+        source: str | MuxedAccount,
         signer: Keypair,
         soroban_server: SorobanServer,
-        network_passphrase: Optional[str] = None,
+        network_passphrase: str | None = None,
         base_fee: int = 100,
         submit_timeout: int = 120,
     ) -> str:

--- a/stellar_sdk/contract/contract_client_async.py
+++ b/stellar_sdk/contract/contract_client_async.py
@@ -1,4 +1,5 @@
-from typing import Callable, Optional, Sequence, TypeVar, Union
+from collections.abc import Sequence
+from typing import Callable, TypeVar
 
 from .. import Account, Asset, Keypair, MuxedAccount, SorobanServerAsync, scval
 from .. import xdr as stellar_xdr
@@ -33,7 +34,7 @@ class ContractClientAsync:
         contract_id: str,
         rpc_url: str,
         network_passphrase: str,
-        request_client: Optional[BaseAsyncClient] = None,
+        request_client: BaseAsyncClient | None = None,
     ):
         self.contract_id = contract_id
         self.rpc_url = rpc_url
@@ -43,10 +44,10 @@ class ContractClientAsync:
     async def invoke(
         self,
         function_name: str,
-        parameters: Optional[Sequence[stellar_xdr.SCVal]] = None,
-        source: Union[str, MuxedAccount] = NULL_ACCOUNT,
-        signer: Optional[Keypair] = None,
-        parse_result_xdr_fn: Optional[Callable[[stellar_xdr.SCVal], T]] = None,
+        parameters: Sequence[stellar_xdr.SCVal] | None = None,
+        source: str | MuxedAccount = NULL_ACCOUNT,
+        signer: Keypair | None = None,
+        parse_result_xdr_fn: Callable[[stellar_xdr.SCVal], T] | None = None,
         base_fee: int = 100,
         transaction_timeout: int = 300,
         submit_timeout: int = 30,
@@ -85,11 +86,11 @@ class ContractClientAsync:
 
     @staticmethod
     async def upload_contract_wasm(
-        contract: Union[bytes, str],
-        source: Union[str, MuxedAccount],
+        contract: bytes | str,
+        source: str | MuxedAccount,
         signer: Keypair,
         soroban_server: SorobanServerAsync,
-        network_passphrase: Optional[str] = None,
+        network_passphrase: str | None = None,
         base_fee: int = 100,
         transaction_timeout: int = 300,
         submit_timeout: int = 120,
@@ -129,13 +130,13 @@ class ContractClientAsync:
 
     @staticmethod
     async def create_contract(
-        wasm_id: Union[bytes, str],
-        source: Union[str, MuxedAccount],
+        wasm_id: bytes | str,
+        source: str | MuxedAccount,
         signer: Keypair,
         soroban_server: SorobanServerAsync,
-        constructor_args: Optional[Sequence[stellar_xdr.SCVal]] = None,
-        salt: Optional[bytes] = None,
-        network_passphrase: Optional[str] = None,
+        constructor_args: Sequence[stellar_xdr.SCVal] | None = None,
+        salt: bytes | None = None,
+        network_passphrase: str | None = None,
         base_fee: int = 100,
         transaction_timeout: int = 300,
         submit_timeout: int = 120,
@@ -181,10 +182,10 @@ class ContractClientAsync:
     @staticmethod
     async def create_stellar_asset_contract_from_asset(
         asset: Asset,
-        source: Union[str, MuxedAccount],
+        source: str | MuxedAccount,
         signer: Keypair,
         soroban_server: SorobanServerAsync,
-        network_passphrase: Optional[str] = None,
+        network_passphrase: str | None = None,
         base_fee: int = 100,
         submit_timeout: int = 120,
     ) -> str:
@@ -219,9 +220,3 @@ class ContractClientAsync:
         ).sign_and_submit(force=True)
         assert isinstance(contract_id, str)
         return contract_id
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
-        await self.server.close()

--- a/stellar_sdk/contract/exceptions.py
+++ b/stellar_sdk/contract/exceptions.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from ..exceptions import SdkError
 
@@ -26,9 +26,7 @@ class AssembledTransactionError(SdkError):
     def __init__(
         self,
         message,
-        assembled_transaction: Union[
-            "AssembledTransaction", "AssembledTransactionAsync"
-        ],
+        assembled_transaction: "AssembledTransaction | AssembledTransactionAsync",
     ) -> None:
         super().__init__(message)
         self.assembled_transaction = assembled_transaction

--- a/stellar_sdk/exceptions.py
+++ b/stellar_sdk/exceptions.py
@@ -1,5 +1,4 @@
 from json import JSONDecodeError
-from typing import Optional
 
 from .client.response import Response
 
@@ -102,11 +101,11 @@ class BaseHorizonError(BaseRequestError):
             message = response.json()
         except JSONDecodeError:
             pass  # pragma: no cover
-        self.type: Optional[str] = message.get("type")
-        self.title: Optional[str] = message.get("title")
-        self.detail: Optional[str] = message.get("detail")
-        self.extras: Optional[dict] = message.get("extras")
-        self.result_xdr: Optional[str] = message.get("extras", {}).get("result_xdr")
+        self.type: str | None = message.get("type")
+        self.title: str | None = message.get("title")
+        self.detail: str | None = message.get("detail")
+        self.extras: dict | None = message.get("extras")
+        self.result_xdr: str | None = message.get("extras", {}).get("result_xdr")
 
     def __repr__(self):
         return self.message
@@ -170,9 +169,7 @@ class FeatureNotEnabledError(SdkError):
 class SorobanRpcErrorResponse(BaseRequestError):
     """The exception is thrown when the RPC server returns an error response."""
 
-    def __init__(
-        self, code: int, message: Optional[str], data: Optional[str] = None
-    ) -> None:
+    def __init__(self, code: int, message: str | None, data: str | None = None) -> None:
         super().__init__(message)
         self.code = code
         self.data = data

--- a/stellar_sdk/fee_bump_transaction.py
+++ b/stellar_sdk/fee_bump_transaction.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from . import xdr as stellar_xdr
 from .keypair import Keypair
 from .muxed_account import MuxedAccount
@@ -23,7 +21,7 @@ class FeeBumpTransaction:
 
     def __init__(
         self,
-        fee_source: Union[MuxedAccount, Keypair, str],
+        fee_source: MuxedAccount | Keypair | str,
         fee: int,
         inner_transaction_envelope: TransactionEnvelope,
     ) -> None:

--- a/stellar_sdk/fee_bump_transaction_envelope.py
+++ b/stellar_sdk/fee_bump_transaction_envelope.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, Union
+from collections.abc import Sequence
 
 from xdrlib3 import Packer
 
@@ -33,7 +33,7 @@ class FeeBumpTransactionEnvelope(BaseTransactionEnvelope["FeeBumpTransactionEnve
         self,
         transaction: FeeBumpTransaction,
         network_passphrase: str,
-        signatures: Optional[Sequence[DecoratedSignature]] = None,
+        signatures: Sequence[DecoratedSignature] | None = None,
     ) -> None:
         super().__init__(network_passphrase, signatures)
         self.transaction: FeeBumpTransaction = transaction
@@ -58,7 +58,7 @@ class FeeBumpTransactionEnvelope(BaseTransactionEnvelope["FeeBumpTransactionEnve
         return network_id + packer.get_buffer()
 
     @staticmethod
-    def is_fee_bump_transaction_envelope(xdr: Union[str, bytes]) -> bool:
+    def is_fee_bump_transaction_envelope(xdr: str | bytes) -> bool:
         if isinstance(xdr, str):
             xdr_object = stellar_xdr.TransactionEnvelope.from_xdr(xdr)
         else:

--- a/stellar_sdk/helpers.py
+++ b/stellar_sdk/helpers.py
@@ -1,5 +1,4 @@
 import warnings
-from typing import Union
 
 from .fee_bump_transaction_envelope import FeeBumpTransactionEnvelope
 from .transaction_envelope import TransactionEnvelope
@@ -9,7 +8,7 @@ __all__ = ["parse_transaction_envelope_from_xdr"]
 
 def parse_transaction_envelope_from_xdr(
     xdr: str, network_passphrase: str
-) -> Union[TransactionEnvelope, FeeBumpTransactionEnvelope]:
+) -> TransactionEnvelope | FeeBumpTransactionEnvelope:
     """When you are not sure whether your XDR belongs to
     :py:class:`TransactionEnvelope <stellar_sdk.transaction_envelope.TransactionEnvelope>`
     or :py:class:`FeeBumpTransactionEnvelope <stellar_sdk.fee_bump_transaction_envelope.FeeBumpTransactionEnvelope>`,

--- a/stellar_sdk/keypair.py
+++ b/stellar_sdk/keypair.py
@@ -1,5 +1,5 @@
 import os
-from typing import Iterable, List, Optional, Union
+from collections.abc import Iterable
 
 import nacl.signing as ed25519
 from nacl.exceptions import BadSignatureError as NaclBadSignatureError
@@ -37,10 +37,10 @@ class Keypair:
     def __init__(
         self,
         verify_key: ed25519.VerifyKey,
-        signing_key: Optional[ed25519.SigningKey] = None,
+        signing_key: ed25519.SigningKey | None = None,
     ) -> None:
         self.verify_key: ed25519.VerifyKey = verify_key
-        self.signing_key: Optional[ed25519.SigningKey] = signing_key
+        self.signing_key: ed25519.SigningKey | None = signing_key
 
     @classmethod
     def random(cls) -> "Keypair":
@@ -217,7 +217,7 @@ class Keypair:
 
     @staticmethod
     def generate_mnemonic_phrase(
-        language: Union[Language, str] = Language.ENGLISH, strength: int = 128
+        language: Language | str = Language.ENGLISH, strength: int = 128
     ) -> str:
         """Generate a mnemonic phrase.
 
@@ -233,7 +233,7 @@ class Keypair:
     def from_mnemonic_phrase(
         cls,
         mnemonic_phrase: str,
-        language: Union[Language, str] = Language.ENGLISH,
+        language: Language | str = Language.ENGLISH,
         passphrase: str = "",
         index: int = 0,
     ) -> "Keypair":
@@ -266,7 +266,7 @@ class Keypair:
         member_count: int,
         passphrase: str = "",
         strength: int = 256,
-    ) -> List[str]:
+    ) -> list[str]:
         """Generate mnemonic phrases using Shamir secret sharing method.
 
         A randomly generated secret key is generated and split into `member_count`
@@ -372,7 +372,7 @@ class Keypair:
         return DecoratedSignature(hint, signature)
 
     @staticmethod
-    def _calculate_message_hash(message: Union[str, bytes]) -> bytes:
+    def _calculate_message_hash(message: str | bytes) -> bytes:
         """Calculate the hash of a message according to `SEP-53 <https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0053.md>`__.
 
         :param message: The message to hash, as a string or bytes.
@@ -384,7 +384,7 @@ class Keypair:
         signed_message_base = message_prefix + message
         return sha256(signed_message_base)
 
-    def sign_message(self, message: Union[str, bytes]) -> bytes:
+    def sign_message(self, message: str | bytes) -> bytes:
         """Sign a message according to `SEP-53 <https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0053.md>`__.
 
         :param message: The message to sign, as a string or bytes.
@@ -393,7 +393,7 @@ class Keypair:
         message_hash = self._calculate_message_hash(message)
         return self.sign(message_hash)
 
-    def verify_message(self, message: Union[str, bytes], signature: bytes) -> None:
+    def verify_message(self, message: str | bytes, signature: bytes) -> None:
         """Verify a `SEP-53 <https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0053.md>`__ signed message.
 
         :param message: The original message, as a string or bytes.

--- a/stellar_sdk/memo.py
+++ b/stellar_sdk/memo.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-from typing import Union
 
 from . import xdr as stellar_xdr
 from .exceptions import MemoInvalidException
@@ -100,7 +99,7 @@ class TextMemo(Memo):
         if ``text`` is not a valid text memo.
     """
 
-    def __init__(self, text: Union[str, bytes]) -> None:
+    def __init__(self, text: str | bytes) -> None:
         self.memo_text = (
             bytes(text, encoding="utf-8") if isinstance(text, str) else text
         )
@@ -183,7 +182,7 @@ class HashMemo(Memo):
         if ``memo_hash`` is not a valid hash memo.
     """
 
-    def __init__(self, memo_hash: Union[bytes, str]) -> None:
+    def __init__(self, memo_hash: bytes | str) -> None:
         memo_hash = hex_to_bytes(memo_hash)
         length = len(memo_hash)
         if length != 32:
@@ -230,7 +229,7 @@ class ReturnHashMemo(Memo):
         if ``memo_return`` is not a valid return hash memo.
     """
 
-    def __init__(self, memo_return: Union[bytes, str]) -> None:
+    def __init__(self, memo_return: bytes | str) -> None:
         memo_return = hex_to_bytes(memo_return)
         length = len(memo_return)
         if length != 32:

--- a/stellar_sdk/muxed_account.py
+++ b/stellar_sdk/muxed_account.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from . import xdr as stellar_xdr
 from .keypair import Keypair
 from .strkey import StrKey
@@ -37,17 +35,17 @@ class MuxedAccount:
     :param account_muxed_id: account multiplexing id, can be ``None`` or a non-negative integer. (ex. ``1234``)
     """
 
-    def __init__(self, account_id: str, account_muxed_id: Optional[int] = None) -> None:
+    def __init__(self, account_id: str, account_muxed_id: int | None = None) -> None:
         if account_muxed_id is not None and account_muxed_id < 0:
             raise ValueError(
                 "`account_muxed_id` must be a non-negative integer if provided."
             )
         Keypair.from_public_key(account_id)
         self.account_id: str = account_id
-        self.account_muxed_id: Optional[int] = account_muxed_id
+        self.account_muxed_id: int | None = account_muxed_id
 
     @property
-    def account_muxed(self) -> Optional[str]:
+    def account_muxed(self) -> str | None:
         """Get the multiplex address starting with ``M``, return ``None`` if `account_id_id` is ``None``."""
 
         if self.account_muxed_id is None:

--- a/stellar_sdk/operation/account_merge.py
+++ b/stellar_sdk/operation/account_merge.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..muxed_account import MuxedAccount
@@ -29,8 +29,8 @@ class AccountMerge(Operation):
 
     def __init__(
         self,
-        destination: Union[MuxedAccount, str],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        destination: MuxedAccount | str,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         if isinstance(destination, str):

--- a/stellar_sdk/operation/allow_trust.py
+++ b/stellar_sdk/operation/allow_trust.py
@@ -1,6 +1,6 @@
 import warnings
 from enum import IntFlag
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..asset import Asset
@@ -61,8 +61,8 @@ class AllowTrust(Operation):
         self,
         trustor: str,
         asset_code: str,
-        authorize: Union[TrustLineEntryFlag, bool],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        authorize: TrustLineEntryFlag | bool,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         # We keep this class to ensure that the SDK can correctly parse historical transactions.
         warnings.warn(

--- a/stellar_sdk/operation/begin_sponsoring_future_reserves.py
+++ b/stellar_sdk/operation/begin_sponsoring_future_reserves.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..keypair import Keypair
@@ -30,7 +30,7 @@ class BeginSponsoringFutureReserves(Operation):
     )
 
     def __init__(
-        self, sponsored_id: str, source: Optional[Union[MuxedAccount, str]] = None
+        self, sponsored_id: str, source: MuxedAccount | str | None = None
     ) -> None:
         super().__init__(source)
         self.sponsored_id: str = sponsored_id

--- a/stellar_sdk/operation/bump_sequence.py
+++ b/stellar_sdk/operation/bump_sequence.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..muxed_account import MuxedAccount
@@ -29,9 +29,7 @@ class BumpSequence(Operation):
         stellar_xdr.OperationType.BUMP_SEQUENCE
     )
 
-    def __init__(
-        self, bump_to: int, source: Optional[Union[MuxedAccount, str]] = None
-    ) -> None:
+    def __init__(self, bump_to: int, source: MuxedAccount | str | None = None) -> None:
         super().__init__(source)
         self.bump_to: int = bump_to
 

--- a/stellar_sdk/operation/change_trust.py
+++ b/stellar_sdk/operation/change_trust.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..asset import Asset
@@ -38,9 +38,9 @@ class ChangeTrust(Operation):
 
     def __init__(
         self,
-        asset: Union[Asset, LiquidityPoolAsset],
-        limit: Union[str, Decimal, None] = None,  # _DEFAULT_LIMIT default
-        source: Optional[Union[MuxedAccount, str]] = None,
+        asset: Asset | LiquidityPoolAsset,
+        limit: str | Decimal | None = None,  # _DEFAULT_LIMIT default
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         self.asset = asset
@@ -72,7 +72,7 @@ class ChangeTrust(Operation):
             xdr_object.body.change_trust_op.line.type
             == stellar_xdr.AssetType.ASSET_TYPE_POOL_SHARE
         ):
-            line: Union[Asset, LiquidityPoolAsset] = LiquidityPoolAsset.from_xdr_object(
+            line: Asset | LiquidityPoolAsset = LiquidityPoolAsset.from_xdr_object(
                 xdr_object.body.change_trust_op.line
             )
         else:

--- a/stellar_sdk/operation/claim_claimable_balance.py
+++ b/stellar_sdk/operation/claim_claimable_balance.py
@@ -1,6 +1,6 @@
 import base64
 import binascii
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..muxed_account import MuxedAccount
@@ -31,7 +31,7 @@ class ClaimClaimableBalance(Operation):
     def __init__(
         self,
         balance_id: str,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         self.balance_id: str = balance_id

--- a/stellar_sdk/operation/clawback.py
+++ b/stellar_sdk/operation/clawback.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..asset import Asset
@@ -34,9 +34,9 @@ class Clawback(Operation):
     def __init__(
         self,
         asset: Asset,
-        from_: Union[MuxedAccount, str],
-        amount: Union[str, Decimal],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        from_: MuxedAccount | str,
+        amount: str | Decimal,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         if isinstance(from_, str):

--- a/stellar_sdk/operation/clawback_claimable_balance.py
+++ b/stellar_sdk/operation/clawback_claimable_balance.py
@@ -1,6 +1,6 @@
 import base64
 import binascii
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..muxed_account import MuxedAccount
@@ -30,7 +30,7 @@ class ClawbackClaimableBalance(Operation):
     )
 
     def __init__(
-        self, balance_id: str, source: Optional[Union[MuxedAccount, str]] = None
+        self, balance_id: str, source: MuxedAccount | str | None = None
     ) -> None:
         super().__init__(source)
         self.balance_id: str = balance_id

--- a/stellar_sdk/operation/create_account.py
+++ b/stellar_sdk/operation/create_account.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..keypair import Keypair
@@ -38,8 +38,8 @@ class CreateAccount(Operation):
     def __init__(
         self,
         destination: str,
-        starting_balance: Union[str, Decimal],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        starting_balance: str | Decimal,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         self.destination: str = destination

--- a/stellar_sdk/operation/create_claimable_balance.py
+++ b/stellar_sdk/operation/create_claimable_balance.py
@@ -1,6 +1,7 @@
+from collections.abc import Sequence
 from decimal import Decimal
 from enum import IntEnum
-from typing import ClassVar, Optional, Sequence, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..asset import Asset
@@ -63,11 +64,11 @@ class ClaimPredicate:
     def __init__(
         self,
         claim_predicate_type: ClaimPredicateType,
-        and_predicates: Optional[ClaimPredicateGroup],
-        or_predicates: Optional[ClaimPredicateGroup],
-        not_predicate: Optional["ClaimPredicate"],
-        abs_before: Optional[int],
-        rel_before: Optional[int],
+        and_predicates: ClaimPredicateGroup | None,
+        or_predicates: ClaimPredicateGroup | None,
+        not_predicate: "ClaimPredicate | None",
+        abs_before: int | None,
+        rel_before: int | None,
     ) -> None:
         self.claim_predicate_type = claim_predicate_type
         self.and_predicates = and_predicates
@@ -330,7 +331,7 @@ class Claimant:
     """
 
     def __init__(
-        self, destination: str, predicate: Optional[ClaimPredicate] = None
+        self, destination: str, predicate: ClaimPredicate | None = None
     ) -> None:
         self.destination = destination
         if predicate is None:
@@ -400,9 +401,9 @@ class CreateClaimableBalance(Operation):
     def __init__(
         self,
         asset: Asset,
-        amount: Union[str, Decimal],
+        amount: str | Decimal,
         claimants: Sequence[Claimant],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         self.asset: Asset = asset

--- a/stellar_sdk/operation/create_passive_sell_offer.py
+++ b/stellar_sdk/operation/create_passive_sell_offer.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..asset import Asset
@@ -53,9 +53,9 @@ class CreatePassiveSellOffer(Operation):
         self,
         selling: Asset,
         buying: Asset,
-        amount: Union[str, Decimal],
-        price: Union[Price, str, Decimal],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        amount: str | Decimal,
+        price: Price | str | Decimal,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         if not isinstance(price, Price):

--- a/stellar_sdk/operation/end_sponsoring_future_reserves.py
+++ b/stellar_sdk/operation/end_sponsoring_future_reserves.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..muxed_account import MuxedAccount
@@ -25,7 +25,7 @@ class EndSponsoringFutureReserves(Operation):
         stellar_xdr.OperationType.END_SPONSORING_FUTURE_RESERVES
     )
 
-    def __init__(self, source: Optional[Union[MuxedAccount, str]] = None) -> None:
+    def __init__(self, source: MuxedAccount | str | None = None) -> None:
         super().__init__(source)
 
     def _to_operation_body(self) -> stellar_xdr.OperationBody:

--- a/stellar_sdk/operation/extend_footprint_ttl.py
+++ b/stellar_sdk/operation/extend_footprint_ttl.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..muxed_account import MuxedAccount
@@ -25,7 +25,7 @@ class ExtendFootprintTTL(Operation):
     )
 
     def __init__(
-        self, extend_to: int, source: Optional[Union[MuxedAccount, str]] = None
+        self, extend_to: int, source: MuxedAccount | str | None = None
     ) -> None:
         super().__init__(source)
         if extend_to < 0 or extend_to > 2**32 - 1:

--- a/stellar_sdk/operation/inflation.py
+++ b/stellar_sdk/operation/inflation.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..muxed_account import MuxedAccount
@@ -22,7 +22,7 @@ class Inflation(Operation):
         stellar_xdr.OperationType.INFLATION
     )
 
-    def __init__(self, source: Optional[Union[MuxedAccount, str]] = None) -> None:
+    def __init__(self, source: MuxedAccount | str | None = None) -> None:
         super().__init__(source)
 
     def _to_operation_body(self) -> stellar_xdr.OperationBody:

--- a/stellar_sdk/operation/invoke_host_function.py
+++ b/stellar_sdk/operation/invoke_host_function.py
@@ -1,4 +1,5 @@
-from typing import ClassVar, List, Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..muxed_account import MuxedAccount
@@ -27,12 +28,12 @@ class InvokeHostFunction(Operation):
     def __init__(
         self,
         host_function: stellar_xdr.HostFunction,
-        auth: Optional[Sequence[stellar_xdr.SorobanAuthorizationEntry]] = None,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        auth: Sequence[stellar_xdr.SorobanAuthorizationEntry] | None = None,
+        source: MuxedAccount | str | None = None,
     ):
         super().__init__(source)
         self.host_function = host_function
-        self.auth: List[stellar_xdr.SorobanAuthorizationEntry] = (
+        self.auth: list[stellar_xdr.SorobanAuthorizationEntry] = (
             list(auth) if auth else []
         )
 

--- a/stellar_sdk/operation/liquidity_pool_deposit.py
+++ b/stellar_sdk/operation/liquidity_pool_deposit.py
@@ -1,6 +1,6 @@
 import binascii
 from decimal import Decimal
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..muxed_account import MuxedAccount
@@ -37,11 +37,11 @@ class LiquidityPoolDeposit(Operation):
     def __init__(
         self,
         liquidity_pool_id: str,
-        max_amount_a: Union[str, Decimal],
-        max_amount_b: Union[str, Decimal],
-        min_price: Union[str, Decimal, Price],
-        max_price: Union[str, Decimal, Price],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        max_amount_a: str | Decimal,
+        max_amount_b: str | Decimal,
+        min_price: str | Decimal | Price,
+        max_price: str | Decimal | Price,
+        source: MuxedAccount | str | None = None,
     ):
         super().__init__(source)
         self.liquidity_pool_id: str = liquidity_pool_id

--- a/stellar_sdk/operation/liquidity_pool_withdraw.py
+++ b/stellar_sdk/operation/liquidity_pool_withdraw.py
@@ -1,6 +1,6 @@
 import binascii
 from decimal import Decimal
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..muxed_account import MuxedAccount
@@ -35,10 +35,10 @@ class LiquidityPoolWithdraw(Operation):
     def __init__(
         self,
         liquidity_pool_id: str,
-        amount: Union[str, Decimal],
-        min_amount_a: Union[str, Decimal],
-        min_amount_b: Union[str, Decimal],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        amount: str | Decimal,
+        min_amount_a: str | Decimal,
+        min_amount_b: str | Decimal,
+        source: MuxedAccount | str | None = None,
     ):
         super().__init__(source)
         self.liquidity_pool_id: str = liquidity_pool_id

--- a/stellar_sdk/operation/manage_buy_offer.py
+++ b/stellar_sdk/operation/manage_buy_offer.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..asset import Asset
@@ -46,10 +46,10 @@ class ManageBuyOffer(Operation):
         self,
         selling: Asset,
         buying: Asset,
-        amount: Union[str, Decimal],
-        price: Union[Price, str, Decimal],
+        amount: str | Decimal,
+        price: Price | str | Decimal,
         offer_id: int = 0,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         if not isinstance(price, Price):

--- a/stellar_sdk/operation/manage_data.py
+++ b/stellar_sdk/operation/manage_data.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..muxed_account import MuxedAccount
@@ -39,14 +39,14 @@ class ManageData(Operation):
     def __init__(
         self,
         data_name: str,
-        data_value: Union[str, bytes, None],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        data_value: str | bytes | None,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         self.data_name: str = data_name
         if isinstance(data_value, str):
             data_value = data_value.encode()
-        self.data_value: Optional[bytes] = data_value
+        self.data_value: bytes | None = data_value
 
         valid_data_name_len = len(self.data_name) <= 64
         valid_data_val_len = self.data_value is None or len(self.data_value) <= 64

--- a/stellar_sdk/operation/manage_sell_offer.py
+++ b/stellar_sdk/operation/manage_sell_offer.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..asset import Asset
@@ -46,10 +46,10 @@ class ManageSellOffer(Operation):
         self,
         selling: Asset,
         buying: Asset,
-        amount: Union[str, Decimal],
-        price: Union[Price, str, Decimal],
+        amount: str | Decimal,
+        price: Price | str | Decimal,
         offer_id: int = 0,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         if not isinstance(price, Price):

--- a/stellar_sdk/operation/operation.py
+++ b/stellar_sdk/operation/operation.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from decimal import Decimal
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import utils
 from .. import xdr as stellar_xdr
@@ -38,13 +38,13 @@ class Operation(metaclass=ABCMeta):
 
     _XDR_OPERATION_TYPE: ClassVar[stellar_xdr.OperationType]
 
-    def __init__(self, source: Optional[Union[MuxedAccount, str]] = None) -> None:
+    def __init__(self, source: MuxedAccount | str | None = None) -> None:
         if isinstance(source, str):
             source = MuxedAccount.from_account(source)
-        self.source: Optional[MuxedAccount] = source
+        self.source: MuxedAccount | None = source
 
     @staticmethod
-    def to_xdr_amount(value: Union[str, Decimal]) -> int:
+    def to_xdr_amount(value: str | Decimal) -> int:
         """Converts an amount to the appropriate value to send over the network
         as a part of an XDR object.
 
@@ -111,7 +111,7 @@ class Operation(metaclass=ABCMeta):
     @staticmethod
     def get_source_from_xdr_obj(
         xdr_object: stellar_xdr.Operation,
-    ) -> Optional[MuxedAccount]:
+    ) -> MuxedAccount | None:
         """Get the source account from account the operation xdr object.
 
         :param xdr_object: the operation xdr object.

--- a/stellar_sdk/operation/path_payment_strict_receive.py
+++ b/stellar_sdk/operation/path_payment_strict_receive.py
@@ -1,5 +1,6 @@
+from collections.abc import Sequence
 from decimal import Decimal
-from typing import ClassVar, Optional, Sequence, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..asset import Asset
@@ -38,13 +39,13 @@ class PathPaymentStrictReceive(Operation):
 
     def __init__(
         self,
-        destination: Union[MuxedAccount, str],
+        destination: MuxedAccount | str,
         send_asset: Asset,
-        send_max: Union[str, Decimal],
+        send_max: str | Decimal,
         dest_asset: Asset,
-        dest_amount: Union[str, Decimal],
+        dest_amount: str | Decimal,
         path: Sequence[Asset],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         if isinstance(destination, str):

--- a/stellar_sdk/operation/path_payment_strict_send.py
+++ b/stellar_sdk/operation/path_payment_strict_send.py
@@ -1,5 +1,6 @@
+from collections.abc import Sequence
 from decimal import Decimal
-from typing import ClassVar, Optional, Sequence, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..asset import Asset
@@ -38,13 +39,13 @@ class PathPaymentStrictSend(Operation):
 
     def __init__(
         self,
-        destination: Union[MuxedAccount, str],
+        destination: MuxedAccount | str,
         send_asset: Asset,
-        send_amount: Union[str, Decimal],
+        send_amount: str | Decimal,
         dest_asset: Asset,
-        dest_min: Union[str, Decimal],
+        dest_min: str | Decimal,
         path: Sequence[Asset],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         if isinstance(destination, str):

--- a/stellar_sdk/operation/payment.py
+++ b/stellar_sdk/operation/payment.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..asset import Asset
@@ -34,10 +34,10 @@ class Payment(Operation):
 
     def __init__(
         self,
-        destination: Union[MuxedAccount, str],
+        destination: MuxedAccount | str,
         asset: Asset,
-        amount: Union[str, Decimal],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        amount: str | Decimal,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         if isinstance(destination, str):

--- a/stellar_sdk/operation/restore_footprint.py
+++ b/stellar_sdk/operation/restore_footprint.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..muxed_account import MuxedAccount
@@ -22,7 +22,7 @@ class RestoreFootprint(Operation):
         stellar_xdr.OperationType.RESTORE_FOOTPRINT
     )
 
-    def __init__(self, source: Optional[Union[MuxedAccount, str]] = None) -> None:
+    def __init__(self, source: MuxedAccount | str | None = None) -> None:
         super().__init__(source)
 
     def _to_operation_body(self) -> stellar_xdr.OperationBody:

--- a/stellar_sdk/operation/revoke_sponsorship.py
+++ b/stellar_sdk/operation/revoke_sponsorship.py
@@ -1,7 +1,7 @@
 import base64
 import binascii
 from enum import IntEnum
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..asset import Asset
@@ -33,7 +33,7 @@ class RevokeSponsorshipType(IntEnum):
 
 
 class TrustLine:
-    def __init__(self, account_id: str, asset: Union[Asset, LiquidityPoolId]) -> None:
+    def __init__(self, account_id: str, asset: Asset | LiquidityPoolId) -> None:
         self.account_id = account_id
         self.asset = asset
         raise_if_not_valid_ed25519_public_key(self.account_id, "account_id")
@@ -140,24 +140,24 @@ class RevokeSponsorship(Operation):
     def __init__(
         self,
         revoke_sponsorship_type: RevokeSponsorshipType,
-        account_id: Optional[str],
-        trustline: Optional[TrustLine],
-        offer: Optional[Offer],
-        data: Optional[Data],
-        claimable_balance_id: Optional[str],
-        signer: Optional[Signer],
-        liquidity_pool_id: Optional[str],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        account_id: str | None,
+        trustline: TrustLine | None,
+        offer: Offer | None,
+        data: Data | None,
+        claimable_balance_id: str | None,
+        signer: Signer | None,
+        liquidity_pool_id: str | None,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         self.revoke_sponsorship_type: RevokeSponsorshipType = revoke_sponsorship_type
-        self.account_id: Optional[str] = account_id
-        self.trustline: Optional[TrustLine] = trustline
-        self.offer: Optional[Offer] = offer
-        self.data: Optional[Data] = data
-        self.claimable_balance_id: Optional[str] = claimable_balance_id
-        self.signer: Optional[Signer] = signer
-        self.liquidity_pool_id: Optional[str] = liquidity_pool_id
+        self.account_id: str | None = account_id
+        self.trustline: TrustLine | None = trustline
+        self.offer: Offer | None = offer
+        self.data: Data | None = data
+        self.claimable_balance_id: str | None = claimable_balance_id
+        self.signer: Signer | None = signer
+        self.liquidity_pool_id: str | None = liquidity_pool_id
 
         if self.account_id is not None:
             raise_if_not_valid_ed25519_public_key(self.account_id, "account_id")
@@ -170,7 +170,7 @@ class RevokeSponsorship(Operation):
 
     @classmethod
     def revoke_account_sponsorship(
-        cls, account_id: str, source: Optional[Union[MuxedAccount, str]] = None
+        cls, account_id: str, source: MuxedAccount | str | None = None
     ):
         """Create a **revoke sponsorship** operation for an account.
 
@@ -194,8 +194,8 @@ class RevokeSponsorship(Operation):
     def revoke_trustline_sponsorship(
         cls,
         account_id: str,
-        asset: Union[Asset, LiquidityPoolId],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        asset: Asset | LiquidityPoolId,
+        source: MuxedAccount | str | None = None,
     ):
         """Create a **revoke sponsorship** operation for a trustline.
 
@@ -222,7 +222,7 @@ class RevokeSponsorship(Operation):
         cls,
         seller_id: str,
         offer_id: int,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ):
         """Create a **revoke sponsorship** operation for an offer.
 
@@ -249,7 +249,7 @@ class RevokeSponsorship(Operation):
         cls,
         account_id: str,
         data_name: str,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ):
         """Create a **revoke sponsorship** operation for a data entry.
 
@@ -275,7 +275,7 @@ class RevokeSponsorship(Operation):
     def revoke_claimable_balance_sponsorship(
         cls,
         claimable_balance_id: str,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ):
         """Create a **revoke sponsorship** operation for a claimable balance.
 
@@ -300,7 +300,7 @@ class RevokeSponsorship(Operation):
         cls,
         account_id: str,
         signer_key: SignerKey,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ):
         """Create a **revoke sponsorship** operation for a signer.
 
@@ -324,7 +324,7 @@ class RevokeSponsorship(Operation):
 
     @classmethod
     def revoke_liquidity_pool_sponsorship(
-        cls, liquidity_pool_id: str, source: Optional[Union[MuxedAccount, str]] = None
+        cls, liquidity_pool_id: str, source: MuxedAccount | str | None = None
     ):
         """Create a **revoke sponsorship** operation for a liquidity pool.
 
@@ -477,8 +477,8 @@ class RevokeSponsorship(Operation):
                     ledger_key.trust_line.asset.type
                     == stellar_xdr.AssetType.ASSET_TYPE_POOL_SHARE
                 ):
-                    asset: Union[Asset, LiquidityPoolId] = (
-                        LiquidityPoolId.from_xdr_object(ledger_key.trust_line.asset)
+                    asset: Asset | LiquidityPoolId = LiquidityPoolId.from_xdr_object(
+                        ledger_key.trust_line.asset
                     )
                 else:
                     asset = Asset.from_xdr_object(ledger_key.trust_line.asset)

--- a/stellar_sdk/operation/set_options.py
+++ b/stellar_sdk/operation/set_options.py
@@ -1,6 +1,6 @@
 import warnings
 from enum import IntFlag
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..keypair import Keypair
@@ -84,16 +84,16 @@ class SetOptions(Operation):
 
     def __init__(
         self,
-        inflation_dest: Optional[str] = None,
-        clear_flags: Optional[Union[int, AuthorizationFlag]] = None,
-        set_flags: Optional[Union[int, AuthorizationFlag]] = None,
-        master_weight: Optional[int] = None,
-        low_threshold: Optional[int] = None,
-        med_threshold: Optional[int] = None,
-        high_threshold: Optional[int] = None,
-        signer: Optional[Signer] = None,
-        home_domain: Optional[str] = None,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        inflation_dest: str | None = None,
+        clear_flags: int | AuthorizationFlag | None = None,
+        set_flags: int | AuthorizationFlag | None = None,
+        master_weight: int | None = None,
+        low_threshold: int | None = None,
+        med_threshold: int | None = None,
+        high_threshold: int | None = None,
+        signer: Signer | None = None,
+        home_domain: str | None = None,
+        source: MuxedAccount | str | None = None,
     ) -> None:
         super().__init__(source)
         if set_flags is not None and not isinstance(set_flags, AuthorizationFlag):
@@ -111,14 +111,14 @@ class SetOptions(Operation):
             clear_flags = AuthorizationFlag(clear_flags)
 
         self.inflation_dest = inflation_dest
-        self.clear_flags: Optional[AuthorizationFlag] = clear_flags
-        self.set_flags: Optional[AuthorizationFlag] = set_flags
-        self.master_weight: Optional[int] = master_weight
-        self.low_threshold: Optional[int] = low_threshold
-        self.med_threshold: Optional[int] = med_threshold
-        self.high_threshold: Optional[int] = high_threshold
-        self.home_domain: Optional[str] = home_domain
-        self.signer: Optional[Signer] = signer
+        self.clear_flags: AuthorizationFlag | None = clear_flags
+        self.set_flags: AuthorizationFlag | None = set_flags
+        self.master_weight: int | None = master_weight
+        self.low_threshold: int | None = low_threshold
+        self.med_threshold: int | None = med_threshold
+        self.high_threshold: int | None = high_threshold
+        self.home_domain: str | None = home_domain
+        self.signer: Signer | None = signer
         if self.inflation_dest is not None:
             raise_if_not_valid_ed25519_public_key(self.inflation_dest, "inflation_dest")
 

--- a/stellar_sdk/operation/set_trust_line_flags.py
+++ b/stellar_sdk/operation/set_trust_line_flags.py
@@ -1,5 +1,5 @@
 from enum import IntFlag
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from .. import xdr as stellar_xdr
 from ..asset import Asset
@@ -55,15 +55,15 @@ class SetTrustLineFlags(Operation):
         self,
         trustor: str,
         asset: Asset,
-        clear_flags: Optional[TrustLineFlags] = None,
-        set_flags: Optional[TrustLineFlags] = None,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        clear_flags: TrustLineFlags | None = None,
+        set_flags: TrustLineFlags | None = None,
+        source: MuxedAccount | str | None = None,
     ):
         super().__init__(source)
         self.trustor: str = trustor
         self.asset: Asset = asset
-        self.clear_flags: Optional[TrustLineFlags] = clear_flags
-        self.set_flags: Optional[TrustLineFlags] = set_flags
+        self.clear_flags: TrustLineFlags | None = clear_flags
+        self.set_flags: TrustLineFlags | None = set_flags
         raise_if_not_valid_ed25519_public_key(self.trustor, "trustor")
 
     def _to_operation_body(self) -> stellar_xdr.OperationBody:

--- a/stellar_sdk/preconditions.py
+++ b/stellar_sdk/preconditions.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Sequence
+from collections.abc import Sequence
 
 from . import xdr as stellar_xdr
 from .ledger_bounds import LedgerBounds
@@ -28,12 +28,12 @@ class Preconditions:
 
     def __init__(
         self,
-        time_bounds: Optional[TimeBounds] = None,
-        ledger_bounds: Optional[LedgerBounds] = None,
-        min_sequence_number: Optional[int] = None,
-        min_sequence_age: Optional[int] = None,
-        min_sequence_ledger_gap: Optional[int] = None,
-        extra_signers: Optional[Sequence[SignerKey]] = None,
+        time_bounds: TimeBounds | None = None,
+        ledger_bounds: LedgerBounds | None = None,
+        min_sequence_number: int | None = None,
+        min_sequence_age: int | None = None,
+        min_sequence_ledger_gap: int | None = None,
+        extra_signers: Sequence[SignerKey] | None = None,
     ):
         if not extra_signers:
             extra_signers = []
@@ -156,7 +156,7 @@ class Preconditions:
             )
             min_sequence_age = xdr_object.v2.min_seq_age.duration.uint64
             min_sequence_ledger_gap = xdr_object.v2.min_seq_ledger_gap.uint32
-            extra_signers: Optional[List[SignerKey]] = [
+            extra_signers: list[SignerKey] | None = [
                 SignerKey.from_xdr_object(s) for s in xdr_object.v2.extra_signers
             ]
             return cls(

--- a/stellar_sdk/price.py
+++ b/stellar_sdk/price.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from typing import Union
 
 from . import xdr as stellar_xdr
 from .utils import best_rational_approximation
@@ -26,7 +25,7 @@ class Price:
         self.d: int = d
 
     @classmethod
-    def from_raw_price(cls, price: Union[str, Decimal]) -> "Price":
+    def from_raw_price(cls, price: str | Decimal) -> "Price":
         """Create a :class:`Price` from the given str or Decimal price.
 
         :param price: the str or Decimal price. (ex. ``"0.125"``)

--- a/stellar_sdk/scval.py
+++ b/stellar_sdk/scval.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import Any
 
 from . import xdr as stellar_xdr
 from .address import Address
@@ -50,17 +51,19 @@ __all__ = [
 ]
 
 
-def to_native(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> Union[
-    bool,
-    None,
-    int,
-    str,
-    bytes,
-    Address,
-    stellar_xdr.SCVal,
-    List[Any],
-    Dict[Any, Any],
-]:
+def to_native(
+    sc_val: stellar_xdr.SCVal | bytes | str,
+) -> (
+    bool
+    | None
+    | int
+    | str
+    | bytes
+    | Address
+    | stellar_xdr.SCVal
+    | list[Any]
+    | dict[Any, Any]
+):
     """Given a :class:`stellar_xdr.SCVal` value, attempt to convert it to a native Python type.
 
     Possible conversions include:
@@ -130,7 +133,7 @@ def to_native(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> Union[
     return sc_val
 
 
-def to_address(data: Union[Address, str]) -> stellar_xdr.SCVal:
+def to_address(data: Address | str) -> stellar_xdr.SCVal:
     """Creates a new :class:`stellar_sdk.xdr.SCVal` XDR object from an :class:`stellar_sdk.address.Address` object.
 
     :param data: The :class:`stellar_sdk.address.Address` object to convert.
@@ -143,7 +146,7 @@ def to_address(data: Union[Address, str]) -> stellar_xdr.SCVal:
     )
 
 
-def from_address(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> Address:
+def from_address(sc_val: stellar_xdr.SCVal | bytes | str) -> Address:
     """Creates an :class:`stellar_sdk.address.Address` object from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -167,7 +170,7 @@ def to_bool(data: bool) -> stellar_xdr.SCVal:
     return stellar_xdr.SCVal(stellar_xdr.SCValType.SCV_BOOL, b=data)
 
 
-def from_bool(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> bool:
+def from_bool(sc_val: stellar_xdr.SCVal | bytes | str) -> bool:
     """Creates a bool value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -190,7 +193,7 @@ def to_void() -> stellar_xdr.SCVal:
     return stellar_xdr.SCVal(stellar_xdr.SCValType.SCV_VOID)
 
 
-def from_void(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> None:
+def from_void(sc_val: stellar_xdr.SCVal | bytes | str) -> None:
     """Creates a None value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -215,7 +218,7 @@ def to_bytes(data: bytes) -> stellar_xdr.SCVal:
     )
 
 
-def from_bytes(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> bytes:
+def from_bytes(sc_val: stellar_xdr.SCVal | bytes | str) -> bytes:
     """Creates a bytes value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -243,7 +246,7 @@ def to_duration(data: int) -> stellar_xdr.SCVal:
     return stellar_xdr.SCVal(stellar_xdr.SCValType.SCV_DURATION, duration=duration)
 
 
-def from_duration(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> int:
+def from_duration(sc_val: stellar_xdr.SCVal | bytes | str) -> int:
     """Creates an int value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -273,7 +276,7 @@ def to_int32(data: int) -> stellar_xdr.SCVal:
     return stellar_xdr.SCVal(stellar_xdr.SCValType.SCV_I32, i32=stellar_xdr.Int32(data))
 
 
-def from_int32(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> int:
+def from_int32(sc_val: stellar_xdr.SCVal | bytes | str) -> int:
     """Creates an int value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -301,7 +304,7 @@ def to_int64(data: int) -> stellar_xdr.SCVal:
     return stellar_xdr.SCVal(stellar_xdr.SCValType.SCV_I64, i64=stellar_xdr.Int64(data))
 
 
-def from_int64(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> int:
+def from_int64(sc_val: stellar_xdr.SCVal | bytes | str) -> int:
     """Creates an int value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -334,7 +337,7 @@ def to_int128(data: int) -> stellar_xdr.SCVal:
     return stellar_xdr.SCVal(stellar_xdr.SCValType.SCV_I128, i128=i128)
 
 
-def from_int128(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> int:
+def from_int128(sc_val: stellar_xdr.SCVal | bytes | str) -> int:
     """Creates an int value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -379,7 +382,7 @@ def to_int256(data: int) -> stellar_xdr.SCVal:
     return stellar_xdr.SCVal(stellar_xdr.SCValType.SCV_I256, i256=i256)
 
 
-def from_int256(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> int:
+def from_int256(sc_val: stellar_xdr.SCVal | bytes | str) -> int:
     """Creates an int value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -401,7 +404,7 @@ def from_int256(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> int:
     return int.from_bytes(value_bytes, "big", signed=True)
 
 
-def to_map(data: Dict[stellar_xdr.SCVal, stellar_xdr.SCVal]) -> stellar_xdr.SCVal:
+def to_map(data: dict[stellar_xdr.SCVal, stellar_xdr.SCVal]) -> stellar_xdr.SCVal:
     """Creates a new :class:`stellar_sdk.xdr.SCVal` XDR object from an OrderedDict value.
 
     :param data: The dict value to convert.
@@ -419,8 +422,8 @@ def to_map(data: Dict[stellar_xdr.SCVal, stellar_xdr.SCVal]) -> stellar_xdr.SCVa
 
 
 def from_map(
-    sc_val: Union[stellar_xdr.SCVal, bytes, str],
-) -> Dict[stellar_xdr.SCVal, stellar_xdr.SCVal]:
+    sc_val: stellar_xdr.SCVal | bytes | str,
+) -> dict[stellar_xdr.SCVal, stellar_xdr.SCVal]:
     """Creates a dict value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -435,7 +438,7 @@ def from_map(
     return dict([(entry.key, entry.val) for entry in sc_val.map.sc_map])
 
 
-def to_string(data: Union[str, bytes]) -> stellar_xdr.SCVal:
+def to_string(data: str | bytes) -> stellar_xdr.SCVal:
     """Creates a new :class:`stellar_sdk.xdr.SCVal` XDR object from a string value.
 
     :param data: The string value to convert.
@@ -448,7 +451,7 @@ def to_string(data: Union[str, bytes]) -> stellar_xdr.SCVal:
     )
 
 
-def from_string(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> bytes:
+def from_string(sc_val: stellar_xdr.SCVal | bytes | str) -> bytes:
     """Creates a string value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -474,7 +477,7 @@ def to_symbol(data: str) -> stellar_xdr.SCVal:
     )
 
 
-def from_symbol(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> str:
+def from_symbol(sc_val: stellar_xdr.SCVal | bytes | str) -> str:
     """Creates a symbol value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -502,7 +505,7 @@ def to_timepoint(data: int) -> stellar_xdr.SCVal:
     return stellar_xdr.SCVal(stellar_xdr.SCValType.SCV_TIMEPOINT, timepoint=time_point)
 
 
-def from_timepoint(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> int:
+def from_timepoint(sc_val: stellar_xdr.SCVal | bytes | str) -> int:
     """Creates an int value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -534,7 +537,7 @@ def to_uint32(data: int) -> stellar_xdr.SCVal:
     )
 
 
-def from_uint32(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> int:
+def from_uint32(sc_val: stellar_xdr.SCVal | bytes | str) -> int:
     """Creates an int value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -564,7 +567,7 @@ def to_uint64(data: int) -> stellar_xdr.SCVal:
     )
 
 
-def from_uint64(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> int:
+def from_uint64(sc_val: stellar_xdr.SCVal | bytes | str) -> int:
     """Creates an int value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -597,7 +600,7 @@ def to_uint128(data: int) -> stellar_xdr.SCVal:
     return stellar_xdr.SCVal(stellar_xdr.SCValType.SCV_U128, u128=u128)
 
 
-def from_uint128(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> int:
+def from_uint128(sc_val: stellar_xdr.SCVal | bytes | str) -> int:
     """Creates an int value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -642,7 +645,7 @@ def to_uint256(data: int) -> stellar_xdr.SCVal:
     return stellar_xdr.SCVal(stellar_xdr.SCValType.SCV_U256, u256=u256)
 
 
-def from_uint256(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> int:
+def from_uint256(sc_val: stellar_xdr.SCVal | bytes | str) -> int:
     """Creates an int value from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -675,7 +678,7 @@ def to_vec(data: Sequence[stellar_xdr.SCVal]) -> stellar_xdr.SCVal:
     )
 
 
-def from_vec(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> List[stellar_xdr.SCVal]:
+def from_vec(sc_val: stellar_xdr.SCVal | bytes | str) -> list[stellar_xdr.SCVal]:
     """Creates a list of :class:`stellar_sdk.xdr.SCVal` XDR objects from a :class:`stellar_sdk.xdr.SCVal` XDR object.
 
     :param sc_val: The :class:`stellar_sdk.xdr.SCVal` XDR object to convert.
@@ -691,7 +694,7 @@ def from_vec(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> List[stellar_xdr.S
 
 
 def to_enum(
-    key: str, data: Optional[Union[stellar_xdr.SCVal, List[stellar_xdr.SCVal]]]
+    key: str, data: stellar_xdr.SCVal | list[stellar_xdr.SCVal] | None
 ) -> stellar_xdr.SCVal:
     """Creates a :class:`stellar_sdk.xdr.SCVal` XDR object corresponding to the Enum in the Rust SDK.
 
@@ -713,8 +716,8 @@ def to_enum(
 
 
 def from_enum(
-    sc_val: Union[stellar_xdr.SCVal, bytes, str],
-) -> Tuple[str, Optional[Union[stellar_xdr.SCVal, List[stellar_xdr.SCVal]]]]:
+    sc_val: stellar_xdr.SCVal | bytes | str,
+) -> tuple[str, stellar_xdr.SCVal | list[stellar_xdr.SCVal] | None]:
     """Creates a tuple corresponding to the Enum in the Rust SDK.
 
     .. warning::
@@ -754,8 +757,8 @@ def to_tuple_struct(data: Sequence[stellar_xdr.SCVal]) -> stellar_xdr.SCVal:
 
 
 def from_tuple_struct(
-    sc_val: Union[stellar_xdr.SCVal, bytes, str],
-) -> List[stellar_xdr.SCVal]:
+    sc_val: stellar_xdr.SCVal | bytes | str,
+) -> list[stellar_xdr.SCVal]:
     """Creates a list corresponding to the Tuple Struct in the Rust SDK.
 
     .. warning::
@@ -769,7 +772,7 @@ def from_tuple_struct(
     return from_vec(sc_val)
 
 
-def to_struct(data: Dict[str, stellar_xdr.SCVal]) -> stellar_xdr.SCVal:
+def to_struct(data: dict[str, stellar_xdr.SCVal]) -> stellar_xdr.SCVal:
     """Creates a new :class:`stellar_sdk.xdr.SCVal` XDR object corresponding to the Struct in the Rust SDK.
 
     .. warning::
@@ -789,8 +792,8 @@ def to_struct(data: Dict[str, stellar_xdr.SCVal]) -> stellar_xdr.SCVal:
 
 
 def from_struct(
-    sc_val: Union[stellar_xdr.SCVal, bytes, str],
-) -> Dict[str, stellar_xdr.SCVal]:
+    sc_val: stellar_xdr.SCVal | bytes | str,
+) -> dict[str, stellar_xdr.SCVal]:
     """Creates a dict corresponding to the Struct in the Rust SDK.
 
     .. warning::
@@ -805,7 +808,7 @@ def from_struct(
     return dict([(from_symbol(key), val) for key, val in v.items()])
 
 
-def _parse_sc_val(sc_val: Union[stellar_xdr.SCVal, bytes, str]) -> stellar_xdr.SCVal:
+def _parse_sc_val(sc_val: stellar_xdr.SCVal | bytes | str) -> stellar_xdr.SCVal:
     if isinstance(sc_val, bytes):
         return stellar_xdr.SCVal.from_xdr_bytes(sc_val)
     elif isinstance(sc_val, str):

--- a/stellar_sdk/sep/federation.py
+++ b/stellar_sdk/sep/federation.py
@@ -8,8 +8,6 @@ Updated: 2019-10-10
 Version 1.1.0
 """
 
-from typing import Dict, Optional
-
 from ..client.aiohttp_client import AiohttpClient
 from ..client.base_async_client import BaseAsyncClient
 from ..client.base_sync_client import BaseSyncClient
@@ -39,8 +37,8 @@ class FederationRecord:
         self,
         account_id: str,
         stellar_address: str,
-        memo_type: Optional[str],
-        memo: Optional[str],
+        memo_type: str | None,
+        memo: str | None,
     ) -> None:
         """The :class:`FederationRecord`, which represents record in federation server.
 
@@ -53,8 +51,8 @@ class FederationRecord:
         """
         self.account_id: str = account_id
         self.stellar_address: str = stellar_address
-        self.memo_type: Optional[str] = memo_type
-        self.memo: Optional[str] = memo
+        self.memo_type: str | None = memo_type
+        self.memo: str | None = memo
 
     def __hash__(self):
         return hash((self.account_id, self.stellar_address, self.memo_type, self.memo))
@@ -78,8 +76,8 @@ class FederationRecord:
 
 def resolve_stellar_address(
     stellar_address: str,
-    client: Optional[BaseSyncClient] = None,
-    federation_url: Optional[str] = None,
+    client: BaseSyncClient | None = None,
+    federation_url: str | None = None,
     use_http: bool = False,
 ) -> FederationRecord:
     """Get the federation record if the user was found for a given Stellar address.
@@ -110,8 +108,8 @@ def resolve_stellar_address(
 
 async def resolve_stellar_address_async(
     stellar_address: str,
-    client: Optional[BaseAsyncClient] = None,
-    federation_url: Optional[str] = None,
+    client: BaseAsyncClient | None = None,
+    federation_url: str | None = None,
     use_http: bool = False,
 ) -> FederationRecord:
     """Get the federation record if the user was found for a given Stellar address.
@@ -142,9 +140,9 @@ async def resolve_stellar_address_async(
 
 def resolve_account_id(
     account_id: str,
-    domain: Optional[str] = None,
-    federation_url: Optional[str] = None,
-    client: Optional[BaseSyncClient] = None,
+    domain: str | None = None,
+    federation_url: str | None = None,
+    client: BaseSyncClient | None = None,
     use_http: bool = False,
 ) -> FederationRecord:
     """Given an account ID, get their federation record if the user was found
@@ -177,9 +175,9 @@ def resolve_account_id(
 
 async def resolve_account_id_async(
     account_id: str,
-    domain: Optional[str] = None,
-    federation_url: Optional[str] = None,
-    client: Optional[BaseAsyncClient] = None,
+    domain: str | None = None,
+    federation_url: str | None = None,
+    client: BaseAsyncClient | None = None,
     use_http: bool = False,
 ) -> FederationRecord:
     """Given an account ID, get their federation record if the user was found
@@ -231,7 +229,7 @@ def _handle_raw_response(
     )
 
 
-def _split_stellar_address(address: str) -> Dict[str, str]:
+def _split_stellar_address(address: str) -> dict[str, str]:
     parts = address.split(SEPARATOR)
     if len(parts) != 2:
         raise InvalidFederationAddress(

--- a/stellar_sdk/sep/mnemonic.py
+++ b/stellar_sdk/sep/mnemonic.py
@@ -8,7 +8,6 @@ import hmac
 import os
 import struct
 from enum import Enum, unique
-from typing import Union
 
 from mnemonic import Mnemonic
 from mnemonic.mnemonic import PBKDF2_ROUNDS
@@ -37,7 +36,7 @@ class StellarMnemonic(Mnemonic):
     FIRST_HARDENED_INDEX = 0x80000000
     SEED_MODIFIER = b"ed25519 seed"
 
-    def __init__(self, language: Union[str, Language] = Language.ENGLISH) -> None:
+    def __init__(self, language: str | Language = Language.ENGLISH) -> None:
         if isinstance(language, Language):
             language = language.value
         else:

--- a/stellar_sdk/sep/stellar_toml.py
+++ b/stellar_sdk/sep/stellar_toml.py
@@ -9,7 +9,8 @@ Version: 2.1.0
 """
 
 import sys
-from typing import Any, MutableMapping, Optional
+from collections.abc import MutableMapping
+from typing import Any
 
 if sys.version_info >= (3, 11):
     from tomllib import loads as toml_loads
@@ -28,7 +29,7 @@ __all__ = ["fetch_stellar_toml", "fetch_stellar_toml_async"]
 
 def fetch_stellar_toml(
     domain: str,
-    client: Optional[BaseSyncClient] = None,
+    client: BaseSyncClient | None = None,
     use_http: bool = False,
 ) -> MutableMapping[str, Any]:
     """Retrieve the stellar.toml file from a given domain.
@@ -54,7 +55,7 @@ def fetch_stellar_toml(
 
 async def fetch_stellar_toml_async(
     domain: str,
-    client: Optional[BaseAsyncClient] = None,
+    client: BaseAsyncClient | None = None,
     use_http: bool = False,
 ) -> MutableMapping[str, Any]:
     """Retrieve the stellar.toml file from a given domain.

--- a/stellar_sdk/sep/stellar_uri.py
+++ b/stellar_sdk/sep/stellar_uri.py
@@ -11,7 +11,6 @@ Version: 2.0.0
 import abc
 import base64
 from decimal import Decimal
-from typing import Dict, List, Optional, Tuple, Union
 from urllib import parse
 
 from ..asset import Asset
@@ -26,7 +25,7 @@ STELLAR_SCHEME: str = "web+stellar"
 
 
 class StellarUri(object, metaclass=abc.ABCMeta):
-    def __init__(self, signature: Optional[str] = None):
+    def __init__(self, signature: str | None = None):
         self.signature = signature
 
     @abc.abstractmethod
@@ -42,7 +41,7 @@ class StellarUri(object, metaclass=abc.ABCMeta):
         sign_data = b"\0" * 35 + b"\4" + b"stellar.sep.7 - URI Scheme" + data.encode()
         return sign_data
 
-    def sign(self, signer: Union[Keypair, str]) -> None:
+    def sign(self, signer: Keypair | str) -> None:
         """Sign the URI.
 
         :param signer: The account used to sign this transaction, it should be the secret key of `URI_REQUEST_SIGNING_KEY`.
@@ -54,11 +53,11 @@ class StellarUri(object, metaclass=abc.ABCMeta):
         self.signature = base64.b64encode(signature).decode()
 
     @staticmethod
-    def _parse_uri_query(uri_query) -> Dict[str, str]:
+    def _parse_uri_query(uri_query) -> dict[str, str]:
         return dict(parse.parse_qsl(uri_query))
 
     @staticmethod
-    def _parse_callback(callback: Optional[str]) -> Optional[str]:
+    def _parse_callback(callback: str | None) -> str | None:
         if callback is None:
             return None
         if not callback.startswith("url:"):
@@ -85,14 +84,14 @@ class PayStellarUri(StellarUri):
     def __init__(
         self,
         destination: str,
-        amount: Union[str, Decimal, None] = None,
-        asset: Optional[Asset] = None,
-        memo: Optional[Memo] = None,
-        callback: Optional[str] = None,
-        message: Optional[str] = None,
-        network_passphrase: Optional[str] = None,
-        origin_domain: Optional[str] = None,
-        signature: Optional[str] = None,
+        amount: str | Decimal | None = None,
+        asset: Asset | None = None,
+        memo: Memo | None = None,
+        callback: str | None = None,
+        message: str | None = None,
+        network_passphrase: str | None = None,
+        origin_domain: str | None = None,
+        signature: str | None = None,
     ) -> None:
         super().__init__(signature)
         if message is not None and len(message) > 300:
@@ -119,7 +118,7 @@ class PayStellarUri(StellarUri):
         self.origin_domain = origin_domain
 
     @staticmethod
-    def _encode_memo(memo) -> Union[Tuple[str, Union[str, int]], Tuple[None, None]]:
+    def _encode_memo(memo) -> tuple[str, str | int] | tuple[None, None]:
         if memo and not isinstance(memo, NoneMemo):
             if isinstance(memo, TextMemo):
                 memo_text = memo.memo_text.decode()  # memo text cant decode?
@@ -142,9 +141,7 @@ class PayStellarUri(StellarUri):
         return None, None
 
     @staticmethod
-    def _decode_memo(
-        memo_type: Optional[str], memo_value: Optional[str]
-    ) -> Optional[Memo]:
+    def _decode_memo(memo_type: str | None, memo_value: str | None) -> Memo | None:
         if memo_type is None:
             return None
         if memo_value is None:
@@ -167,7 +164,7 @@ class PayStellarUri(StellarUri):
 
         :return: Stellar Pay URI.
         """
-        query_params: Dict[str, Union[str, int, None]] = {}
+        query_params: dict[str, str | int | None] = {}
         query_params["destination"] = self.destination
         if self.amount is not None:
             query_params["amount"] = self.amount
@@ -346,14 +343,14 @@ class TransactionStellarUri(StellarUri):
 
     def __init__(
         self,
-        transaction_envelope: Union[TransactionEnvelope, FeeBumpTransactionEnvelope],
-        replace: Optional[List[Replacement]] = None,
-        callback: Optional[str] = None,
-        pubkey: Optional[str] = None,
-        message: Optional[str] = None,
-        network_passphrase: Optional[str] = None,
-        origin_domain: Optional[str] = None,
-        signature: Optional[str] = None,
+        transaction_envelope: TransactionEnvelope | FeeBumpTransactionEnvelope,
+        replace: list[Replacement] | None = None,
+        callback: str | None = None,
+        pubkey: str | None = None,
+        message: str | None = None,
+        network_passphrase: str | None = None,
+        origin_domain: str | None = None,
+        signature: str | None = None,
     ) -> None:
         super().__init__(signature)
         if message is not None and len(message) > 300:
@@ -368,7 +365,7 @@ class TransactionStellarUri(StellarUri):
         self.origin_domain = origin_domain
 
     @property
-    def _replace(self) -> Optional[str]:
+    def _replace(self) -> str | None:
         if not self.replace:
             return None
         replaces = []
@@ -406,7 +403,7 @@ class TransactionStellarUri(StellarUri):
 
     @classmethod
     def from_uri(
-        cls, uri: str, network_passphrase: Optional[str]
+        cls, uri: str, network_passphrase: str | None
     ) -> "TransactionStellarUri":
         """Parse Stellar Transaction URI and generate :class:`TransactionStellarUri` object.
 
@@ -447,7 +444,7 @@ class TransactionStellarUri(StellarUri):
         msg = query.get("msg")
         origin_domain = query.get("origin_domain")
         signature = query.get("signature")
-        tx: Union[TransactionEnvelope, FeeBumpTransactionEnvelope]
+        tx: TransactionEnvelope | FeeBumpTransactionEnvelope
         if xdr is None:
             raise ValueError("`xdr` is missing from uri.")
         if FeeBumpTransactionEnvelope.is_fee_bump_transaction_envelope(xdr):

--- a/stellar_sdk/sep/stellar_web_authentication.py
+++ b/stellar_sdk/sep/stellar_web_authentication.py
@@ -11,7 +11,7 @@ Version 3.3.0
 import base64
 import os
 import time
-from typing import Iterable, List, Optional, Sequence, Union
+from collections.abc import Iterable, Sequence
 
 from .. import xdr as stellar_xdr
 from ..account import Account
@@ -52,7 +52,7 @@ class ChallengeTransaction:
         transaction: TransactionEnvelope,
         client_account_id: str,
         matched_home_domain: str,
-        memo: Optional[int] = None,
+        memo: int | None = None,
     ) -> None:
         self.transaction = transaction
         self.client_account_id = client_account_id
@@ -90,9 +90,9 @@ def build_challenge_transaction(
     web_auth_domain: str,
     network_passphrase: str,
     timeout: int = 900,
-    client_domain: Optional[str] = None,
-    client_signing_key: Optional[str] = None,
-    memo: Optional[int] = None,
+    client_domain: str | None = None,
+    client_signing_key: str | None = None,
+    memo: int | None = None,
 ) -> str:
     """Returns a valid `SEP0010 <https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md>`_
     challenge transaction which you can use for Stellar Web Authentication.
@@ -152,7 +152,7 @@ def build_challenge_transaction(
 def read_challenge_transaction(
     challenge_transaction: str,
     server_account_id: str,
-    home_domains: Union[str, Iterable[str]],
+    home_domains: str | Iterable[str],
     web_auth_domain: str,
     network_passphrase: str,
 ) -> ChallengeTransaction:
@@ -332,11 +332,11 @@ def read_challenge_transaction(
 def verify_challenge_transaction_signers(
     challenge_transaction: str,
     server_account_id: str,
-    home_domains: Union[str, Iterable[str]],
+    home_domains: str | Iterable[str],
     web_auth_domain: str,
     network_passphrase: str,
     signers: Sequence[Ed25519PublicKeySigner],
-) -> List[Ed25519PublicKeySigner]:
+) -> list[Ed25519PublicKeySigner]:
     """Verifies that for a SEP 10 challenge transaction
     all signatures on the transaction are accounted for. A transaction is
     verified if it is signed by the server account, and all other signatures
@@ -403,7 +403,7 @@ def verify_challenge_transaction_signers(
     all_signers = client_signers + additional_signers
     all_signers_found = _verify_transaction_signatures(te, all_signers)
 
-    signers_found: List[Ed25519PublicKeySigner] = []
+    signers_found: list[Ed25519PublicKeySigner] = []
     server_signer_found = False
     client_signing_key_found = False
     for signer in all_signers_found:
@@ -444,7 +444,7 @@ def verify_challenge_transaction_signers(
 def verify_challenge_transaction_signed_by_client_master_key(
     challenge_transaction: str,
     server_account_id: str,
-    home_domains: Union[str, Iterable[str]],
+    home_domains: str | Iterable[str],
     web_auth_domain: str,
     network_passphrase: str,
 ) -> None:
@@ -475,12 +475,12 @@ def verify_challenge_transaction_signed_by_client_master_key(
 def verify_challenge_transaction_threshold(
     challenge_transaction: str,
     server_account_id: str,
-    home_domains: Union[str, Iterable[str]],
+    home_domains: str | Iterable[str],
     web_auth_domain: str,
     network_passphrase: str,
     threshold: int,
     signers: Sequence[Ed25519PublicKeySigner],
-) -> List[Ed25519PublicKeySigner]:
+) -> list[Ed25519PublicKeySigner]:
     """Verifies that for a SEP 10 challenge transaction
     all signatures on the transaction are accounted for and that the signatures
     meet a threshold on an account. A transaction is verified if it is signed by
@@ -525,7 +525,7 @@ def verify_challenge_transaction_threshold(
 def verify_challenge_transaction(
     challenge_transaction: str,
     server_account_id: str,
-    home_domains: Union[str, Iterable[str]],
+    home_domains: str | Iterable[str],
     web_auth_domain: str,
     network_passphrase: str,
 ) -> None:
@@ -577,7 +577,7 @@ def verify_challenge_transaction(
 
 def _verify_transaction_signatures(
     transaction_envelope: TransactionEnvelope, signers: Sequence[Ed25519PublicKeySigner]
-) -> List[Ed25519PublicKeySigner]:
+) -> list[Ed25519PublicKeySigner]:
     """Checks if a transaction has been signed by one or more of
     the signers, returning a list of signers that were found to have signed the
     transaction.

--- a/stellar_sdk/sep/toid.py
+++ b/stellar_sdk/sep/toid.py
@@ -10,8 +10,6 @@ Discussion: https://groups.google.com/g/stellar-dev/c/vCgQhmox32Q
 
 __all__ = ["TOID"]
 
-from typing import Tuple
-
 
 class TOID:
     """TOID represents the total order of Ledgers, Transactions and Operations.
@@ -98,7 +96,7 @@ class TOID:
         return TOID(ledger_sequence, 2**20 - 1, 2**12 - 1)
 
     @staticmethod
-    def ledger_range_inclusive(start: int, end: int) -> Tuple[int, int]:
+    def ledger_range_inclusive(start: int, end: int) -> tuple[int, int]:
         """The inclusive range representation between two
         ledgers inclusive. The second value points at the end+1 ledger so when using
         this value make sure < order is used.

--- a/stellar_sdk/server.py
+++ b/stellar_sdk/server.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from .account import Account
 from .asset import Asset
@@ -42,7 +42,7 @@ class Server(BaseServer):
     def __init__(
         self,
         horizon_url: str = "https://horizon-testnet.stellar.org/",
-        client: Optional[BaseSyncClient] = None,
+        client: BaseSyncClient | None = None,
     ) -> None:
         self.horizon_url: str = horizon_url
 
@@ -52,11 +52,9 @@ class Server(BaseServer):
 
     def submit_transaction(
         self,
-        transaction_envelope: Union[
-            TransactionEnvelope, FeeBumpTransactionEnvelope, str
-        ],
+        transaction_envelope: TransactionEnvelope | FeeBumpTransactionEnvelope | str,
         skip_memo_required_check: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Submits a transaction to the network.
 
         :param transaction_envelope: :class:`stellar_sdk.transaction_envelope.TransactionEnvelope` object
@@ -85,11 +83,9 @@ class Server(BaseServer):
 
     def submit_transaction_async(
         self,
-        transaction_envelope: Union[
-            TransactionEnvelope, FeeBumpTransactionEnvelope, str
-        ],
+        transaction_envelope: TransactionEnvelope | FeeBumpTransactionEnvelope | str,
         skip_memo_required_check: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Submits an asynchronous transaction to the network. Unlike the synchronous version, which blocks
         and waits for the transaction to be ingested in Horizon, this endpoint relays the response from
         core directly back to the user.
@@ -120,7 +116,7 @@ class Server(BaseServer):
         raise_request_exception(resp)
         return resp.json()
 
-    def load_account(self, account_id: Union[MuxedAccount, Keypair, str]) -> Account:
+    def load_account(self, account_id: MuxedAccount | Keypair | str) -> Account:
         """Fetches an account's most current base state (like sequence) in the ledger and then creates
         and returns an :class:`stellar_sdk.account.Account` object.
 
@@ -148,7 +144,7 @@ class Server(BaseServer):
         return account
 
     def __check_memo_required_sync(
-        self, transaction: Union[Transaction, FeeBumpTransaction]
+        self, transaction: Transaction | FeeBumpTransaction
     ) -> None:
         if isinstance(transaction, FeeBumpTransaction):
             transaction = transaction.inner_transaction_envelope.transaction
@@ -283,9 +279,9 @@ class Server(BaseServer):
 
     def strict_receive_paths(
         self,
-        source: Union[str, List[Asset]],
+        source: str | list[Asset],
         destination_asset: Asset,
-        destination_amount: Union[str, Decimal],
+        destination_amount: str | Decimal,
     ) -> StrictReceivePathsCallBuilder:
         """
         :param source: The sender's account ID or a list of Assets. Any returned path must use a source that the sender can hold.
@@ -305,8 +301,8 @@ class Server(BaseServer):
     def strict_send_paths(
         self,
         source_asset: Asset,
-        source_amount: Union[str, Decimal],
-        destination: Union[str, List[Asset]],
+        source_amount: str | Decimal,
+        destination: str | list[Asset],
     ) -> StrictSendPathsCallBuilder:
         """
         :param source_asset: The asset to be sent.
@@ -335,9 +331,9 @@ class Server(BaseServer):
         base: Asset,
         counter: Asset,
         resolution: int,
-        start_time: Optional[int] = None,
-        end_time: Optional[int] = None,
-        offset: Optional[int] = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
+        offset: int | None = None,
     ) -> TradeAggregationsCallBuilder:
         """
         :param base: base asset

--- a/stellar_sdk/server_async.py
+++ b/stellar_sdk/server_async.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from .account import Account
 from .asset import Asset
@@ -46,7 +46,7 @@ class ServerAsync(BaseServer):
     def __init__(
         self,
         horizon_url: str = "https://horizon-testnet.stellar.org/",
-        client: Optional[BaseAsyncClient] = None,
+        client: BaseAsyncClient | None = None,
     ) -> None:
         self.horizon_url: str = horizon_url
 
@@ -56,11 +56,9 @@ class ServerAsync(BaseServer):
 
     async def submit_transaction(
         self,
-        transaction_envelope: Union[
-            TransactionEnvelope, FeeBumpTransactionEnvelope, str
-        ],
+        transaction_envelope: TransactionEnvelope | FeeBumpTransactionEnvelope | str,
         skip_memo_required_check: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Submits a transaction to the network.
 
         :param transaction_envelope: :class:`stellar_sdk.transaction_envelope.TransactionEnvelope` object
@@ -89,11 +87,9 @@ class ServerAsync(BaseServer):
 
     async def submit_transaction_async(
         self,
-        transaction_envelope: Union[
-            TransactionEnvelope, FeeBumpTransactionEnvelope, str
-        ],
+        transaction_envelope: TransactionEnvelope | FeeBumpTransactionEnvelope | str,
         skip_memo_required_check: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Submits an asynchronous transaction to the network. Unlike the synchronous version, which blocks
         and waits for the transaction to be ingested in Horizon, this endpoint relays the response from
         core directly back to the user.
@@ -124,9 +120,7 @@ class ServerAsync(BaseServer):
         raise_request_exception(resp)
         return resp.json()
 
-    async def load_account(
-        self, account_id: Union[MuxedAccount, Keypair, str]
-    ) -> Account:
+    async def load_account(self, account_id: MuxedAccount | Keypair | str) -> Account:
         """Fetches an account's most current base state (like sequence) in the ledger and then creates
         and returns an :class:`stellar_sdk.account.Account` object.
 
@@ -154,7 +148,7 @@ class ServerAsync(BaseServer):
         return account
 
     async def _check_memo_required(
-        self, transaction: Union[Transaction, FeeBumpTransaction]
+        self, transaction: Transaction | FeeBumpTransaction
     ) -> None:
         if isinstance(transaction, FeeBumpTransaction):
             transaction = transaction.inner_transaction_envelope.transaction
@@ -287,9 +281,9 @@ class ServerAsync(BaseServer):
 
     def strict_receive_paths(
         self,
-        source: Union[str, List[Asset]],
+        source: str | list[Asset],
         destination_asset: Asset,
-        destination_amount: Union[str, Decimal],
+        destination_amount: str | Decimal,
     ) -> StrictReceivePathsCallBuilder:
         """
         :param source: The sender's account ID or a list of Assets. Any returned path must use a source that the sender can hold.
@@ -309,8 +303,8 @@ class ServerAsync(BaseServer):
     def strict_send_paths(
         self,
         source_asset: Asset,
-        source_amount: Union[str, Decimal],
-        destination: Union[str, List[Asset]],
+        source_amount: str | Decimal,
+        destination: str | list[Asset],
     ) -> StrictSendPathsCallBuilder:
         """
         :param source_asset: The asset to be sent.
@@ -339,9 +333,9 @@ class ServerAsync(BaseServer):
         base: Asset,
         counter: Asset,
         resolution: int,
-        start_time: Optional[int] = None,
-        end_time: Optional[int] = None,
-        offset: Optional[int] = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
+        offset: int | None = None,
     ) -> TradeAggregationsCallBuilder:
         """
         :param base: base asset

--- a/stellar_sdk/signer.py
+++ b/stellar_sdk/signer.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from . import xdr as stellar_xdr
 from .signer_key import SignerKey
 
@@ -9,7 +7,7 @@ __all__ = ["Signer"]
 class Signer:
     """The :class:`Signer` object, which represents an account signer on Stellar's network.
 
-    An example:
+    An example::
 
         from stellar_sdk import Signer
 
@@ -28,7 +26,7 @@ class Signer:
         self.weight: int = weight
 
     @classmethod
-    def ed25519_public_key(cls, account_id: Union[str, bytes], weight: int) -> "Signer":
+    def ed25519_public_key(cls, account_id: str | bytes, weight: int) -> "Signer":
         """Create ED25519 PUBLIC KEY Signer from account id.
 
         :param account_id: account id (ex. ``"GDNA2V62PVEFBZ74CDJKTUHLY4Y7PL5UAV2MAM4VWF6USFE3SH2354AD"``)
@@ -42,7 +40,7 @@ class Signer:
         return cls(signer_key, weight)
 
     @classmethod
-    def pre_auth_tx(cls, pre_auth_tx_hash: Union[str, bytes], weight: int) -> "Signer":
+    def pre_auth_tx(cls, pre_auth_tx_hash: str | bytes, weight: int) -> "Signer":
         """Create Pre AUTH TX Signer from the sha256 hash of a transaction,
         click `here <https://developers.stellar.org/docs/glossary/multisig/#pre-authorized-transaction>`__ for more information.
 
@@ -55,7 +53,7 @@ class Signer:
         return cls(signer_key, weight)
 
     @classmethod
-    def sha256_hash(cls, sha256_hash: Union[str, bytes], weight: int) -> "Signer":
+    def sha256_hash(cls, sha256_hash: str | bytes, weight: int) -> "Signer":
         """Create SHA256 HASH Signer from a sha256 hash of a preimage,
         click `here <https://developers.stellar.org/docs/glossary/multisig/#hashx>`__ for more information.
 

--- a/stellar_sdk/signer_key.py
+++ b/stellar_sdk/signer_key.py
@@ -1,5 +1,4 @@
 from enum import IntEnum
-from typing import Union
 
 from . import xdr as stellar_xdr
 from .__version__ import __issues__
@@ -89,7 +88,7 @@ class SignerKey:
             raise ValueError(f"{prefix!r} is an unsupported version byte.")
 
     @classmethod
-    def ed25519_public_key(cls, account_id: Union[str, bytes]) -> "SignerKey":
+    def ed25519_public_key(cls, account_id: str | bytes) -> "SignerKey":
         """Create ED25519 PUBLIC KEY Signer from account id.
 
         :param account_id: account id
@@ -104,7 +103,7 @@ class SignerKey:
         return cls(signer_key=account_id, signer_key_type=signer_key_type)
 
     @classmethod
-    def pre_auth_tx(cls, pre_auth_tx_hash: Union[str, bytes]) -> "SignerKey":
+    def pre_auth_tx(cls, pre_auth_tx_hash: str | bytes) -> "SignerKey":
         """Create Pre AUTH TX Signer from the sha256 hash of a transaction,
         click `here <https://developers.stellar.org/docs/glossary/multisig/#pre-authorized-transaction>`__ for more information.
 
@@ -117,7 +116,7 @@ class SignerKey:
         return cls(signer_key=pre_auth_tx_hash, signer_key_type=signer_key_type)
 
     @classmethod
-    def sha256_hash(cls, sha256_hash: Union[str, bytes]) -> "SignerKey":
+    def sha256_hash(cls, sha256_hash: str | bytes) -> "SignerKey":
         """Create SHA256 HASH Signer from a sha256 hash of a preimage,
         click `here <https://developers.stellar.org/docs/glossary/multisig/#hashx>`__ for more information.
 
@@ -131,7 +130,7 @@ class SignerKey:
 
     @classmethod
     def ed25519_signed_payload(
-        cls, ed25519_signed_payload: Union[str, bytes, SignedPayloadSigner]
+        cls, ed25519_signed_payload: str | bytes | SignedPayloadSigner
     ) -> "SignerKey":
         """Create ed25519 signed payload Signer from an ed25519 signed payload,
         click `here <https://github.com/stellar/stellar-protocol/blob/master/core/cap-0040.md>`__ for more information.

--- a/stellar_sdk/soroban_data_builder.py
+++ b/stellar_sdk/soroban_data_builder.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List, Union
-
 from . import xdr as stellar_xdr
 
 __all__ = ["SorobanDataBuilder"]
@@ -35,7 +33,7 @@ class SorobanDataBuilder:
 
     @classmethod
     def from_xdr(
-        cls, soroban_data: Union[str, stellar_xdr.SorobanTransactionData]
+        cls, soroban_data: str | stellar_xdr.SorobanTransactionData
     ) -> SorobanDataBuilder:
         """Create a new :class:`SorobanDataBuilder` object from an XDR object.
 
@@ -61,7 +59,7 @@ class SorobanDataBuilder:
         return self
 
     def set_read_only(
-        self, read_only: List[stellar_xdr.LedgerKey]
+        self, read_only: list[stellar_xdr.LedgerKey]
     ) -> SorobanDataBuilder:
         """Sets the read-only portion of the storage access footprint to be a certain set of ledger keys.
 
@@ -72,7 +70,7 @@ class SorobanDataBuilder:
         return self
 
     def set_read_write(
-        self, read_write: List[stellar_xdr.LedgerKey]
+        self, read_write: list[stellar_xdr.LedgerKey]
     ) -> SorobanDataBuilder:
         """Sets the read-write portion of the storage access footprint to be a certain set of ledger keys.
 

--- a/stellar_sdk/soroban_rpc.py
+++ b/stellar_sdk/soroban_rpc.py
@@ -1,23 +1,14 @@
+from collections.abc import Callable, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    List,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
-)
+from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing_extensions import Self
 
 T = TypeVar("T")
 
-Id = Union[str, int]
+Id = str | int
 
 
 # JSON-RPC 2.0 definitions
@@ -30,13 +21,13 @@ class Request(BaseModel, Generic[T]):
     jsonrpc: str = "2.0"
     id: Id
     method: str
-    params: Optional[T] = None
+    params: T | None = None
 
 
 class Error(BaseModel):
     code: int
-    message: Optional[str] = None
-    data: Optional[str] = None
+    message: str | None = None
+    data: str | None = None
 
 
 class Response(BaseModel, Generic[T]):
@@ -47,8 +38,8 @@ class Response(BaseModel, Generic[T]):
 
     jsonrpc: str
     id: Id
-    result: Optional[T] = None
-    error: Optional[Error] = None
+    result: T | None = None
+    error: Error | None = None
 
 
 # get_events
@@ -59,9 +50,9 @@ class EventFilterType(Enum):
 
 
 class EventFilter(BaseModel):
-    event_type: Optional[EventFilterType] = Field(alias="type", default=None)
-    contract_ids: Optional[Sequence[str]] = Field(alias="contractIds", default=None)
-    topics: Optional[Sequence[Sequence[str]]] = None
+    event_type: EventFilterType | None = Field(alias="type", default=None)
+    contract_ids: Sequence[str] | None = Field(alias="contractIds", default=None)
+    topics: Sequence[Sequence[str]] | None = None
     model_config = ConfigDict(populate_by_name=True)
 
 
@@ -71,7 +62,7 @@ class EventInfo(BaseModel):
     ledger_close_at: datetime = Field(alias="ledgerClosedAt")
     contract_id: str = Field(alias="contractId")
     id: str = Field(alias="id")
-    topic: List[str] = Field(alias="topic")
+    topic: list[str] = Field(alias="topic")
     value: str = Field(alias="value")
     in_successful_contract_call: bool = Field(
         alias="inSuccessfulContractCall",
@@ -84,8 +75,8 @@ class EventInfo(BaseModel):
 
 
 class PaginationOptions(BaseModel):
-    cursor: Optional[str] = None
-    limit: Optional[int] = None
+    cursor: str | None = None
+    limit: int | None = None
 
 
 class PaginationMixin:
@@ -107,10 +98,10 @@ class GetEventsRequest(PaginationMixin, BaseModel):
     more information.
     """
 
-    start_ledger: Optional[int] = Field(alias="startLedger", default=None)
-    end_ledger: Optional[int] = Field(alias="endLedger", default=None)
-    pagination: Optional[PaginationOptions] = None
-    filters: Optional[Sequence[EventFilter]] = None
+    start_ledger: int | None = Field(alias="startLedger", default=None)
+    end_ledger: int | None = Field(alias="endLedger", default=None)
+    pagination: PaginationOptions | None = None
+    filters: Sequence[EventFilter] | None = None
 
 
 class GetEventsResponse(BaseModel):
@@ -120,7 +111,7 @@ class GetEventsResponse(BaseModel):
     more information.
     """
 
-    events: List[EventInfo] = Field(alias="events")
+    events: list[EventInfo] = Field(alias="events")
     latest_ledger: int = Field(alias="latestLedger")
     oldest_ledger: int = Field(alias="oldestLedger")
     latest_Ledger_close_time: int = Field(alias="latestLedgerCloseTime")
@@ -142,7 +133,7 @@ class LedgerEntryResult(BaseModel):
     key: str
     xdr: str
     last_modified_ledger: int = Field(alias="lastModifiedLedgerSeq")
-    live_until_ledger: Optional[int] = Field(alias="liveUntilLedgerSeq", default=None)
+    live_until_ledger: int | None = Field(alias="liveUntilLedgerSeq", default=None)
 
 
 class GetLedgerEntriesResponse(BaseModel):
@@ -151,7 +142,7 @@ class GetLedgerEntriesResponse(BaseModel):
     See `getLedgerEntries documentation <https://developers.stellar.org/docs/data/rpc/api-reference/methods/getLedgerEntries>`__ for
     more information."""
 
-    entries: Optional[List[LedgerEntryResult]] = None
+    entries: list[LedgerEntryResult] | None = None
     latest_ledger: int = Field(alias="latestLedger")
 
 
@@ -162,7 +153,7 @@ class GetNetworkResponse(BaseModel):
     See `getNetwork documentation <https://developers.stellar.org/docs/data/rpc/api-reference/methods/getNetwork>`__ for
     more information."""
 
-    friendbot_url: Optional[str] = Field(alias="friendbotUrl", default=None)
+    friendbot_url: str | None = Field(alias="friendbotUrl", default=None)
     passphrase: str
     protocol_version: int = Field(alias="protocolVersion")
 
@@ -214,10 +205,8 @@ class SimulateTransactionRequest(BaseModel):
     """
 
     transaction: str
-    resource_config: Optional[ResourceConfig] = Field(
-        alias="resourceConfig", default=None
-    )
-    auth_mode: Optional[AuthMode] = Field(alias="authMode", default=None)
+    resource_config: ResourceConfig | None = Field(alias="resourceConfig", default=None)
+    auth_mode: AuthMode | None = Field(alias="authMode", default=None)
     model_config = ConfigDict(populate_by_name=True)
 
 
@@ -227,14 +216,14 @@ class SimulateTransactionCost(BaseModel):
 
 
 class SimulateTransactionResult(BaseModel):
-    auth: Optional[List[str]] = None
-    events: Optional[List[str]] = None
+    auth: list[str] | None = None
+    events: list[str] | None = None
     footprint: str
     xdr: str
 
 
 class SimulateHostFunctionResult(BaseModel):
-    auth: Optional[List[str]] = None
+    auth: list[str] | None = None
     xdr: str
 
 
@@ -253,9 +242,9 @@ class LedgerEntryChange(BaseModel):
     # LedgerEntryKey in base64
     key: str
     # LedgerEntry XDR in base64
-    before: Optional[str] = None
+    before: str | None = None
     # LedgerEntry XDR in base64
-    after: Optional[str] = None
+    after: str | None = None
 
 
 class SimulateTransactionResponse(BaseModel):
@@ -264,19 +253,19 @@ class SimulateTransactionResponse(BaseModel):
     See `simulateTransaction documentation <https://developers.stellar.org/docs/data/rpc/api-reference/methods/simulateTransaction>`__ for
     more information."""
 
-    error: Optional[str] = None
-    transaction_data: Optional[str] = Field(alias="transactionData", default=None)
+    error: str | None = None
+    transaction_data: str | None = Field(alias="transactionData", default=None)
     # SorobanTransactionData XDR in base64
-    min_resource_fee: Optional[int] = Field(alias="minResourceFee", default=None)
-    events: Optional[List[str]] = None
+    min_resource_fee: int | None = Field(alias="minResourceFee", default=None)
+    events: list[str] | None = None
     # DiagnosticEvent XDR in base64
-    results: Optional[List[SimulateHostFunctionResult]] = None
+    results: list[SimulateHostFunctionResult] | None = None
     # the effective cpu and memory cost of the invoked transaction execution.
-    restore_preamble: Optional[RestorePreamble] = Field(
+    restore_preamble: RestorePreamble | None = Field(
         alias="restorePreamble", default=None
     )
     # If present, it indicates how the state (ledger entries) will change as a result of the transaction execution.
-    state_changes: Optional[List[LedgerEntryChange]] = Field(
+    state_changes: list[LedgerEntryChange] | None = Field(
         alias="stateChanges", default=None
     )
     # If present, it indicates that a prior RestoreFootprint is required
@@ -296,7 +285,7 @@ class GetTransactionStatus(Enum):
 class TransactionResponseError(BaseModel):
     code: str
     message: str
-    data: Dict[str, Any]
+    data: dict[str, Any]
 
 
 class GetTransactionRequest(BaseModel):
@@ -310,15 +299,15 @@ class GetTransactionRequest(BaseModel):
 
 class Events(BaseModel):
     # base64-encoded list of `xdr.DiagnosticEvent`s
-    diagnostic_events_xdr: Optional[List[str]] = Field(
+    diagnostic_events_xdr: list[str] | None = Field(
         alias="diagnosticEventsXdr", default=None
     )
     # base64-encoded list of `xdr.TransactionEvent`s
-    transaction_events_xdr: Optional[List[str]] = Field(
+    transaction_events_xdr: list[str] | None = Field(
         alias="transactionEventsXdr", default=None
     )
     # base64-encoded list of lists of `xdr.ContractEvent`s, where each element of the list corresponds to the events for that operation in the transaction
-    contract_events_xdr: Optional[List[List[str]]] = Field(
+    contract_events_xdr: list[list[str]] | None = Field(
         alias="contractEventsXdr", default=None
     )
 
@@ -336,20 +325,20 @@ class GetTransactionResponse(BaseModel):
     oldest_ledger: int = Field(alias="oldestLedger")
     oldest_ledger_close_time: int = Field(alias="oldestLedgerCloseTime")
     # The fields below are only present if Status is not TransactionStatus.NOT_FOUND.
-    application_order: Optional[int] = Field(alias="applicationOrder", default=None)
-    fee_bump: Optional[bool] = Field(alias="feeBump", default=None)
-    envelope_xdr: Optional[str] = Field(
+    application_order: int | None = Field(alias="applicationOrder", default=None)
+    fee_bump: bool | None = Field(alias="feeBump", default=None)
+    envelope_xdr: str | None = Field(
         alias="envelopeXdr", default=None
     )  # stellar_sdk.xdr.TransactionEnvelope
-    result_xdr: Optional[str] = Field(
+    result_xdr: str | None = Field(
         alias="resultXdr", default=None
     )  # stellar_sdk.xdr.TransactionResult
-    result_meta_xdr: Optional[str] = Field(
+    result_meta_xdr: str | None = Field(
         alias="resultMetaXdr", default=None
     )  # stellar_sdk.xdr.TransactionMeta
-    events: Optional[Events] = None
-    ledger: Optional[int] = Field(alias="ledger", default=None)
-    create_at: Optional[int] = Field(alias="createdAt", default=None)
+    events: Events | None = None
+    ledger: int | None = Field(alias="ledger", default=None)
+    create_at: int | None = Field(alias="createdAt", default=None)
 
 
 # send_transaction
@@ -379,8 +368,8 @@ class SendTransactionResponse(BaseModel):
     See `sendTransaction documentation <https://developers.stellar.org/docs/data/rpc/api-reference/methods/sendTransaction>`__ for
     more information."""
 
-    error_result_xdr: Optional[str] = Field(alias="errorResultXdr", default=None)
-    diagnostic_events_xdr: Optional[List[str]] = Field(
+    error_result_xdr: str | None = Field(alias="errorResultXdr", default=None)
+    diagnostic_events_xdr: list[str] | None = Field(
         alias="diagnosticEventsXdr", default=None
     )
     status: SendTransactionStatus = Field(alias="status")
@@ -439,8 +428,8 @@ class GetTransactionsRequest(PaginationMixin, BaseModel):
     See `getTransactions documentation <https://developers.stellar.org/docs/data/rpc/api-reference/methods/getTransactions>`__ for
     more information."""
 
-    start_ledger: Optional[int] = Field(alias="startLedger", default=None)
-    pagination: Optional[PaginationOptions] = None
+    start_ledger: int | None = Field(alias="startLedger", default=None)
+    pagination: PaginationOptions | None = None
 
 
 class Transaction(BaseModel):
@@ -453,13 +442,13 @@ class Transaction(BaseModel):
     result_meta_xdr: str = Field(alias="resultMetaXdr")
     ledger: int
     created_at: int = Field(alias="createdAt")
-    diagnostic_events_xdr: Optional[List[str]] = Field(
+    diagnostic_events_xdr: list[str] | None = Field(
         alias="diagnosticEventsXdr",
         default=None,
         deprecated=True,
         description="This field is deprecated and will be removed in the future. Use `events.diagnostic_events_xdr` instead.",
     )
-    events: Optional[Events] = None
+    events: Events | None = None
 
 
 class GetTransactionsResponse(BaseModel):
@@ -468,7 +457,7 @@ class GetTransactionsResponse(BaseModel):
     See `getTransactions documentation <https://developers.stellar.org/docs/data/rpc/api-reference/methods/getTransactions>`__ for
     more information."""
 
-    transactions: List[Transaction]
+    transactions: list[Transaction]
     latest_ledger: int = Field(alias="latestLedger")
     latest_ledger_close_timestamp: int = Field(alias="latestLedgerCloseTimestamp")
     oldest_ledger: int = Field(alias="oldestLedger")
@@ -497,8 +486,8 @@ class GetLedgersRequest(PaginationMixin, BaseModel):
     See `getLedgers documentation <https://developers.stellar.org/docs/data/rpc/api-reference/methods/getLedgers>`__ for
     more information."""
 
-    start_ledger: Optional[int] = Field(alias="startLedger", default=None)
-    pagination: Optional[PaginationOptions] = None
+    start_ledger: int | None = Field(alias="startLedger", default=None)
+    pagination: PaginationOptions | None = None
 
 
 class LedgerInfo(BaseModel):
@@ -517,7 +506,7 @@ class GetLedgersResponse(BaseModel):
     See `getLedgers documentation <https://developers.stellar.org/docs/data/rpc/api-reference/methods/getLedgers>`__ for
     more information."""
 
-    ledgers: List[LedgerInfo]
+    ledgers: list[LedgerInfo]
     latest_ledger: int = Field(alias="latestLedger")
     latest_ledger_close_time: int = Field(alias="latestLedgerCloseTime")
     oldest_ledger: int = Field(alias="oldestLedger")
@@ -529,15 +518,15 @@ class SACBalanceEntry(BaseModel):
     amount: int
     authorized: bool
     clawback: bool
-    last_modified_ledger: Optional[int] = Field(default=None)
-    live_until_ledger: Optional[int] = Field(default=None)
+    last_modified_ledger: int | None = Field(default=None)
+    live_until_ledger: int | None = Field(default=None)
 
 
 class GetSACBalanceResponse(BaseModel):
     """Response for :meth:`stellar_sdk.SorobanServer.get_sac_balance` and :meth:`stellar_sdk.SorobanServerAsync.get_sac_balance` methods."""
 
     latest_ledger: int
-    balance_entry: Optional[SACBalanceEntry] = Field(
+    balance_entry: SACBalanceEntry | None = Field(
         description="The balance entry for the account. If there is not a valid balance entry, this will be None."
     )
 

--- a/stellar_sdk/soroban_server.py
+++ b/stellar_sdk/soroban_server.py
@@ -55,7 +55,7 @@ class SorobanServer:
     def __init__(
         self,
         server_url: str = "https://soroban-testnet.stellar.org:443",
-        client: Optional[BaseSyncClient] = None,
+        client: BaseSyncClient | None = None,
     ) -> None:
         self.server_url: str = server_url
 
@@ -80,11 +80,11 @@ class SorobanServer:
 
     def get_events(
         self,
-        start_ledger: Optional[int] = None,
-        end_ledger: Optional[int] = None,
-        filters: Optional[Sequence[EventFilter]] = None,
-        cursor: Optional[str] = None,
-        limit: Optional[int] = None,
+        start_ledger: int | None = None,
+        end_ledger: int | None = None,
+        filters: Sequence[EventFilter] | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
     ) -> GetEventsResponse:
         """Fetch a list of events that occurred in the ledger range.
 
@@ -141,7 +141,7 @@ class SorobanServer:
         return self._post(request, GetLatestLedgerResponse)
 
     def get_ledger_entries(
-        self, keys: List[stellar_xdr.LedgerKey]
+        self, keys: list[stellar_xdr.LedgerKey]
     ) -> GetLedgerEntriesResponse:
         """For reading the current value of ledger entries directly.
 
@@ -181,8 +181,8 @@ class SorobanServer:
     def simulate_transaction(
         self,
         transaction_envelope: TransactionEnvelope,
-        addl_resources: Optional[ResourceLeeway] = None,
-        auth_mode: Optional[AuthMode] = None,
+        addl_resources: ResourceLeeway | None = None,
+        auth_mode: AuthMode | None = None,
     ) -> SimulateTransactionResponse:
         """Submit a trial contract invocation to get back return values, expected ledger footprint, and expected costs.
 
@@ -220,9 +220,7 @@ class SorobanServer:
 
     def send_transaction(
         self,
-        transaction_envelope: Union[
-            TransactionEnvelope, FeeBumpTransactionEnvelope, str
-        ],
+        transaction_envelope: TransactionEnvelope | FeeBumpTransactionEnvelope | str,
     ) -> SendTransactionResponse:
         """Submit a real transaction to the Stellar network. This is the only way to make changes "on-chain".
 
@@ -292,9 +290,9 @@ class SorobanServer:
 
     def get_transactions(
         self,
-        start_ledger: Optional[int] = None,
-        cursor: Optional[str] = None,
-        limit: Optional[int] = None,
+        start_ledger: int | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
     ) -> GetTransactionsResponse:
         """Fetch a detailed list of transactions starting from the user specified starting point that you can paginate
         as long as the pages fall within the history retention of their corresponding RPC provider.
@@ -319,9 +317,9 @@ class SorobanServer:
 
     def get_ledgers(
         self,
-        start_ledger: Optional[int] = None,
-        cursor: Optional[str] = None,
-        limit: Optional[int] = None,
+        start_ledger: int | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
     ) -> GetLedgersResponse:
         """Fetch a detailed list of ledgers starting from the user specified starting point that you can paginate
         as long as the pages fall within the history retention of their corresponding RPC provider.
@@ -372,7 +370,7 @@ class SorobanServer:
         contract_id: str,
         key: stellar_xdr.SCVal,
         durability: Durability = Durability.PERSISTENT,
-    ) -> Optional[LedgerEntryResult]:
+    ) -> LedgerEntryResult | None:
         """Reads the current value of contract data ledger entries directly.
 
         :param contract_id: The contract ID containing the data to load. Encoded as Stellar Contract Address,
@@ -419,7 +417,7 @@ class SorobanServer:
         return self._post(request, GetVersionInfoResponse)
 
     def get_sac_balance(
-        self, contract_id: str, sac: Asset, network_passphrase: Optional[str] = None
+        self, contract_id: str, sac: Asset, network_passphrase: str | None = None
     ) -> GetSACBalanceResponse:
         """Returns a contract's balance of a particular SAC asset, if any.
 
@@ -479,7 +477,7 @@ class SorobanServer:
     def prepare_transaction(
         self,
         transaction_envelope: TransactionEnvelope,
-        simulate_transaction_response: Optional[SimulateTransactionResponse] = None,
+        simulate_transaction_response: SimulateTransactionResponse | None = None,
     ) -> TransactionEnvelope:
         """Submit a trial contract invocation, first run a simulation of the contract
         invocation as defined on the incoming transaction, and apply the results to

--- a/stellar_sdk/soroban_server_async.py
+++ b/stellar_sdk/soroban_server_async.py
@@ -55,7 +55,7 @@ class SorobanServerAsync:
     def __init__(
         self,
         server_url: str = "https://soroban-testnet.stellar.org:443",
-        client: Optional[BaseAsyncClient] = None,
+        client: BaseAsyncClient | None = None,
     ) -> None:
         self.server_url: str = server_url
 
@@ -80,11 +80,11 @@ class SorobanServerAsync:
 
     async def get_events(
         self,
-        start_ledger: Optional[int] = None,
-        end_ledger: Optional[int] = None,
-        filters: Optional[Sequence[EventFilter]] = None,
-        cursor: Optional[str] = None,
-        limit: Optional[int] = None,
+        start_ledger: int | None = None,
+        end_ledger: int | None = None,
+        filters: Sequence[EventFilter] | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
     ) -> GetEventsResponse:
         """Fetch a list of events that occurred in the ledger range.
 
@@ -141,7 +141,7 @@ class SorobanServerAsync:
         return await self._post(request, GetLatestLedgerResponse)
 
     async def get_ledger_entries(
-        self, keys: List[stellar_xdr.LedgerKey]
+        self, keys: list[stellar_xdr.LedgerKey]
     ) -> GetLedgerEntriesResponse:
         """For reading the current value of ledger entries directly.
 
@@ -181,8 +181,8 @@ class SorobanServerAsync:
     async def simulate_transaction(
         self,
         transaction_envelope: TransactionEnvelope,
-        addl_resources: Optional[ResourceLeeway] = None,
-        auth_mode: Optional[AuthMode] = None,
+        addl_resources: ResourceLeeway | None = None,
+        auth_mode: AuthMode | None = None,
     ) -> SimulateTransactionResponse:
         """Submit a trial contract invocation to get back return values, expected ledger footprint, and expected costs.
 
@@ -219,9 +219,7 @@ class SorobanServerAsync:
 
     async def send_transaction(
         self,
-        transaction_envelope: Union[
-            TransactionEnvelope, FeeBumpTransactionEnvelope, str
-        ],
+        transaction_envelope: TransactionEnvelope | FeeBumpTransactionEnvelope | str,
     ) -> SendTransactionResponse:
         """Submit a real transaction to the Stellar network. This is the only way to make changes "on-chain".
 
@@ -291,9 +289,9 @@ class SorobanServerAsync:
 
     async def get_transactions(
         self,
-        start_ledger: Optional[int] = None,
-        cursor: Optional[str] = None,
-        limit: Optional[int] = None,
+        start_ledger: int | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
     ) -> GetTransactionsResponse:
         """Fetch a detailed list of transactions starting from the user specified starting point that you can paginate
         as long as the pages fall within the history retention of their corresponding RPC provider.
@@ -318,9 +316,9 @@ class SorobanServerAsync:
 
     async def get_ledgers(
         self,
-        start_ledger: Optional[int] = None,
-        cursor: Optional[str] = None,
-        limit: Optional[int] = None,
+        start_ledger: int | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
     ) -> GetLedgersResponse:
         """Fetch a detailed list of ledgers starting from the user specified starting point that you can paginate
         as long as the pages fall within the history retention of their corresponding RPC provider.
@@ -371,7 +369,7 @@ class SorobanServerAsync:
         contract_id: str,
         key: stellar_xdr.SCVal,
         durability: Durability = Durability.PERSISTENT,
-    ) -> Optional[LedgerEntryResult]:
+    ) -> LedgerEntryResult | None:
         """Reads the current value of contract data ledger entries directly.
 
         :param contract_id: The contract ID containing the data to load. Encoded as Stellar Contract Address,
@@ -418,7 +416,7 @@ class SorobanServerAsync:
         return await self._post(request, GetVersionInfoResponse)
 
     async def get_sac_balance(
-        self, contract_id: str, sac: Asset, network_passphrase: Optional[str] = None
+        self, contract_id: str, sac: Asset, network_passphrase: str | None = None
     ) -> GetSACBalanceResponse:
         """Returns a contract's balance of a particular SAC asset, if any.
 
@@ -478,7 +476,7 @@ class SorobanServerAsync:
     async def prepare_transaction(
         self,
         transaction_envelope: TransactionEnvelope,
-        simulate_transaction_response: Optional[SimulateTransactionResponse] = None,
+        simulate_transaction_response: SimulateTransactionResponse | None = None,
     ) -> TransactionEnvelope:
         """Submit a trial contract invocation, first run a simulation of the contract
         invocation as defined on the incoming transaction, and apply the results to

--- a/stellar_sdk/transaction.py
+++ b/stellar_sdk/transaction.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Sequence, Union
+from collections.abc import Sequence
 
 from . import xdr as stellar_xdr
 from .keypair import Keypair
@@ -57,13 +57,13 @@ class Transaction:
 
     def __init__(
         self,
-        source: Union[MuxedAccount, Keypair, str],
+        source: MuxedAccount | Keypair | str,
         sequence: int,
         fee: int,
         operations: Sequence[Operation],
-        memo: Optional[Memo] = None,
-        preconditions: Optional[Preconditions] = None,
-        soroban_data: Optional[stellar_xdr.SorobanTransactionData] = None,
+        memo: Memo | None = None,
+        preconditions: Preconditions | None = None,
+        soroban_data: stellar_xdr.SorobanTransactionData | None = None,
         v1: bool = True,
     ) -> None:
         # if not operations:
@@ -83,11 +83,11 @@ class Transaction:
 
         self.source: MuxedAccount = source
         self.sequence: int = sequence
-        self.operations: List[Operation] = list(operations) if operations else []
+        self.operations: list[Operation] = list(operations) if operations else []
         self.memo: Memo = memo
         self.fee: int = fee
-        self.preconditions: Optional[Preconditions] = preconditions
-        self.soroban_data: Optional[stellar_xdr.SorobanTransactionData] = (
+        self.preconditions: Preconditions | None = preconditions
+        self.soroban_data: stellar_xdr.SorobanTransactionData | None = (
             SorobanDataBuilder.from_xdr(soroban_data).build() if soroban_data else None
         )
         self.v1: bool = v1
@@ -129,7 +129,7 @@ class Transaction:
 
     def to_xdr_object(
         self,
-    ) -> Union[stellar_xdr.Transaction, stellar_xdr.TransactionV0]:
+    ) -> stellar_xdr.Transaction | stellar_xdr.TransactionV0:
         """Get an XDR object representation of this :class:`Transaction`.
 
         :return: XDR Transaction object
@@ -186,7 +186,7 @@ class Transaction:
     @classmethod
     def from_xdr_object(
         cls,
-        xdr_object: Union[stellar_xdr.Transaction, stellar_xdr.TransactionV0],
+        xdr_object: stellar_xdr.Transaction | stellar_xdr.TransactionV0,
         v1: bool = True,
     ) -> "Transaction":
         """Create a new :class:`Transaction` from an XDR object.

--- a/stellar_sdk/transaction_builder.py
+++ b/stellar_sdk/transaction_builder.py
@@ -3,8 +3,8 @@ import math
 import os
 import time
 import warnings
+from collections.abc import Sequence
 from decimal import Decimal
-from typing import List, Optional, Sequence, Union
 
 from . import StrKey, scval
 from . import xdr as stellar_xdr
@@ -105,17 +105,17 @@ class TransactionBuilder:
         self.source_account: Account = source_account
         self.base_fee: int = base_fee
         self.network_passphrase: str = network_passphrase
-        self.operations: List[Operation] = []
-        self.time_bounds: Optional[TimeBounds] = None
-        self.ledger_bounds: Optional[LedgerBounds] = None
-        self.min_sequence_number: Optional[int] = None
-        self.min_sequence_age: Optional[int] = None
-        self.min_sequence_ledger_gap: Optional[int] = None
-        self.extra_signers: List[SignerKey] = []
+        self.operations: list[Operation] = []
+        self.time_bounds: TimeBounds | None = None
+        self.ledger_bounds: LedgerBounds | None = None
+        self.min_sequence_number: int | None = None
+        self.min_sequence_age: int | None = None
+        self.min_sequence_ledger_gap: int | None = None
+        self.extra_signers: list[SignerKey] = []
         self.memo: Memo = NoneMemo()
         self.v1: bool = v1
 
-        self.soroban_data: Optional[stellar_xdr.SorobanTransactionData] = None
+        self.soroban_data: stellar_xdr.SorobanTransactionData | None = None
 
     def build(self) -> TransactionEnvelope:
         """This will build the transaction envelope.
@@ -162,7 +162,7 @@ class TransactionBuilder:
 
     @staticmethod
     def build_fee_bump_transaction(
-        fee_source: Union[MuxedAccount, Keypair, str],
+        fee_source: MuxedAccount | Keypair | str,
         base_fee: int,
         inner_transaction_envelope: TransactionEnvelope,
         network_passphrase: str = Network.TESTNET_NETWORK_PASSPHRASE,
@@ -220,7 +220,7 @@ class TransactionBuilder:
     @staticmethod
     def from_xdr(
         xdr: str, network_passphrase: str
-    ) -> Union[TransactionEnvelope, FeeBumpTransactionEnvelope]:
+    ) -> TransactionEnvelope | FeeBumpTransactionEnvelope:
         """When you are not sure whether your XDR belongs to
         :py:class:`TransactionEnvelope <stellar_sdk.transaction_envelope.TransactionEnvelope>`
         or :py:class:`FeeBumpTransactionEnvelope <stellar_sdk.fee_bump_transaction_envelope.FeeBumpTransactionEnvelope>`,
@@ -351,7 +351,7 @@ class TransactionBuilder:
         return self
 
     def set_soroban_data(
-        self, soroban_data: Union[stellar_xdr.SorobanTransactionData, str]
+        self, soroban_data: stellar_xdr.SorobanTransactionData | str
     ) -> "TransactionBuilder":
         """Set the SorobanTransactionData. For non-contract(non-Soroban) transactions, this setting has no effect.
 
@@ -367,7 +367,7 @@ class TransactionBuilder:
         return self
 
     def add_extra_signer(
-        self, signer_key: Union[SignerKey, SignedPayloadSigner, str]
+        self, signer_key: SignerKey | SignedPayloadSigner | str
     ) -> "TransactionBuilder":
         """For the transaction to be valid, there must be a signature corresponding to every
         Signer in this array, even if the signature is not otherwise required by
@@ -394,7 +394,7 @@ class TransactionBuilder:
         self.memo = memo
         return self
 
-    def add_text_memo(self, memo_text: Union[str, bytes]) -> "TransactionBuilder":
+    def add_text_memo(self, memo_text: str | bytes) -> "TransactionBuilder":
         """Set the memo for the transaction to a new :class:`TextMemo
         <stellar_sdk.memo.TextMemo>`.
 
@@ -420,7 +420,7 @@ class TransactionBuilder:
         memo = IdMemo(memo_id)
         return self.add_memo(memo)
 
-    def add_hash_memo(self, memo_hash: Union[bytes, str]) -> "TransactionBuilder":
+    def add_hash_memo(self, memo_hash: bytes | str) -> "TransactionBuilder":
         """Set the memo for the transaction to a new :class:`HashMemo
         <stellar_sdk.memo.HashMemo>`.
 
@@ -433,9 +433,7 @@ class TransactionBuilder:
         memo = HashMemo(memo_hash)
         return self.add_memo(memo)
 
-    def add_return_hash_memo(
-        self, memo_return: Union[bytes, str]
-    ) -> "TransactionBuilder":
+    def add_return_hash_memo(self, memo_return: bytes | str) -> "TransactionBuilder":
         """Set the memo for the transaction to a new :class:`RetHashMemo
         <stellar_sdk.memo.ReturnHashMemo>`.
 
@@ -461,8 +459,8 @@ class TransactionBuilder:
     def append_create_account_op(
         self,
         destination: str,
-        starting_balance: Union[str, Decimal],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        starting_balance: str | Decimal,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`CreateAccount
         <stellar_sdk.operation.CreateAccount>` operation to the list of
@@ -481,9 +479,9 @@ class TransactionBuilder:
 
     def append_change_trust_op(
         self,
-        asset: Union[Asset, LiquidityPoolAsset],
-        limit: Optional[Union[str, Decimal]] = None,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        asset: Asset | LiquidityPoolAsset,
+        limit: str | Decimal | None = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`ChangeTrust <stellar_sdk.operation.ChangeTrust>`
         operation to the list of operations.
@@ -500,10 +498,10 @@ class TransactionBuilder:
 
     def append_payment_op(
         self,
-        destination: Union[MuxedAccount, str],
+        destination: MuxedAccount | str,
         asset: Asset,
-        amount: Union[str, Decimal],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        amount: str | Decimal,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`Payment <stellar_sdk.operation.Payment>` operation
         to the list of operations.
@@ -521,13 +519,13 @@ class TransactionBuilder:
 
     def append_path_payment_strict_receive_op(
         self,
-        destination: Union[MuxedAccount, str],
+        destination: MuxedAccount | str,
         send_asset: Asset,
-        send_max: Union[str, Decimal],
+        send_max: str | Decimal,
         dest_asset: Asset,
-        dest_amount: Union[str, Decimal],
+        dest_amount: str | Decimal,
         path: Sequence[Asset],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`PathPaymentStrictReceive <stellar_sdk.operation.PathPaymentStrictReceive>`
         operation to the list of operations.
@@ -556,13 +554,13 @@ class TransactionBuilder:
 
     def append_path_payment_strict_send_op(
         self,
-        destination: Union[MuxedAccount, str],
+        destination: MuxedAccount | str,
         send_asset: Asset,
-        send_amount: Union[str, Decimal],
+        send_amount: str | Decimal,
         dest_asset: Asset,
-        dest_min: Union[str, Decimal],
+        dest_min: str | Decimal,
         path: Sequence[Asset],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`PathPaymentStrictSend <stellar_sdk.operation.PathPaymentStrictSend>`
         operation to the list of operations.
@@ -592,8 +590,8 @@ class TransactionBuilder:
         self,
         trustor: str,
         asset_code: str,
-        authorize: Union[TrustLineEntryFlag, bool],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        authorize: TrustLineEntryFlag | bool,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`AllowTrust <stellar_sdk.operation.AllowTrust>`
         operation to the list of operations.
@@ -618,16 +616,16 @@ class TransactionBuilder:
 
     def append_set_options_op(
         self,
-        inflation_dest: Optional[str] = None,
-        clear_flags: Optional[Union[int, AuthorizationFlag]] = None,
-        set_flags: Optional[Union[int, AuthorizationFlag]] = None,
-        master_weight: Optional[int] = None,
-        low_threshold: Optional[int] = None,
-        med_threshold: Optional[int] = None,
-        high_threshold: Optional[int] = None,
-        home_domain: Optional[str] = None,
-        signer: Optional[Signer] = None,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        inflation_dest: str | None = None,
+        clear_flags: int | AuthorizationFlag | None = None,
+        set_flags: int | AuthorizationFlag | None = None,
+        master_weight: int | None = None,
+        low_threshold: int | None = None,
+        med_threshold: int | None = None,
+        high_threshold: int | None = None,
+        home_domain: str | None = None,
+        signer: Signer | None = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`SetOptions <stellar_sdk.operation.SetOptions>`
         operation to the list of operations.
@@ -688,7 +686,7 @@ class TransactionBuilder:
         self,
         account_id: str,
         weight: int,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Add a ed25519 public key signer to an account via a :class:`SetOptions
         <stellar_sdk.operation.SetOptions` operation. This is a helper
@@ -706,9 +704,9 @@ class TransactionBuilder:
 
     def append_hashx_signer(
         self,
-        sha256_hash: Union[bytes, str],
+        sha256_hash: bytes | str,
         weight: int,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Add a sha256 hash(HashX) signer to an account via a :class:`SetOptions
         <stellar_sdk.operation.SetOptions` operation. This is a helper
@@ -729,7 +727,7 @@ class TransactionBuilder:
         return self.append_set_options_op(signer=signer, source=source)
 
     def append_pre_auth_tx_signer(
-        self, pre_auth_tx_hash: Union[str, bytes], weight: int, source=None
+        self, pre_auth_tx_hash: str | bytes, weight: int, source=None
     ) -> "TransactionBuilder":
         """Add a PreAuthTx signer to an account via a :class:`SetOptions <stellar_sdk.operation.SetOptions` operation.
         This is a helper function for :meth:`append_set_options_op`.
@@ -753,10 +751,10 @@ class TransactionBuilder:
         self,
         selling: Asset,
         buying: Asset,
-        amount: Union[str, Decimal],
-        price: Union[Price, str, Decimal],
+        amount: str | Decimal,
+        price: Price | str | Decimal,
         offer_id: int = 0,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`ManageBuyOffer <stellar_sdk.operation.ManageBuyOffer>`
         operation to the list of operations.
@@ -785,10 +783,10 @@ class TransactionBuilder:
         self,
         selling: Asset,
         buying: Asset,
-        amount: Union[str, Decimal],
-        price: Union[Price, str, Decimal],
+        amount: str | Decimal,
+        price: Price | str | Decimal,
         offer_id: int = 0,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`ManageSellOffer <stellar_sdk.operation.ManageSellOffer>`
         operation to the list of operations.
@@ -817,9 +815,9 @@ class TransactionBuilder:
         self,
         selling: Asset,
         buying: Asset,
-        amount: Union[str, Decimal],
-        price: Union[Price, str, Decimal],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        amount: str | Decimal,
+        price: Price | str | Decimal,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`CreatePassiveSellOffer
         <stellar_sdk.operation.CreatePassiveSellOffer>` operation to the list of
@@ -838,8 +836,8 @@ class TransactionBuilder:
 
     def append_account_merge_op(
         self,
-        destination: Union[MuxedAccount, str],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        destination: MuxedAccount | str,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`AccountMerge
         <stellar_sdk.operation.AccountMerge>` operation to the list of
@@ -856,7 +854,8 @@ class TransactionBuilder:
         return self.append_operation(op)
 
     def append_inflation_op(
-        self, source: Optional[Union[MuxedAccount, str]] = None
+        self,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`Inflation
         <stellar_sdk.operation.Inflation>` operation to the list of
@@ -873,8 +872,8 @@ class TransactionBuilder:
     def append_manage_data_op(
         self,
         data_name: str,
-        data_value: Union[str, bytes, None],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        data_value: str | bytes | None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`ManageData <stellar_sdk.operation.ManageData>`
         operation to the list of operations.
@@ -893,7 +892,9 @@ class TransactionBuilder:
         return self.append_operation(op)
 
     def append_bump_sequence_op(
-        self, bump_to: int, source: Optional[Union[MuxedAccount, str]] = None
+        self,
+        bump_to: int,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`BumpSequence <stellar_sdk.operation.BumpSequence>`
         operation to the list of operations.
@@ -909,9 +910,9 @@ class TransactionBuilder:
     def append_create_claimable_balance_op(
         self,
         asset: Asset,
-        amount: Union[str, Decimal],
+        amount: str | Decimal,
         claimants: Sequence[Claimant],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`CreateClaimableBalance <stellar_sdk.operation.CreateClaimableBalance>`
         operation to the list of operations.
@@ -925,7 +926,9 @@ class TransactionBuilder:
         return self.append_operation(op)
 
     def append_claim_claimable_balance_op(
-        self, balance_id: str, source: Optional[Union[MuxedAccount, str]] = None
+        self,
+        balance_id: str,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`ClaimClaimableBalance <stellar_sdk.operation.ClaimClaimableBalance>`
         operation to the list of operations.
@@ -937,7 +940,9 @@ class TransactionBuilder:
         return self.append_operation(op)
 
     def append_begin_sponsoring_future_reserves_op(
-        self, sponsored_id: str, source: Optional[Union[MuxedAccount, str]] = None
+        self,
+        sponsored_id: str,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`BeginSponsoringFutureReserves <stellar_sdk.operation.BeginSponsoringFutureReserves>`
         operation to the list of operations.
@@ -950,7 +955,8 @@ class TransactionBuilder:
         return self.append_operation(op)
 
     def append_end_sponsoring_future_reserves_op(
-        self, source: Optional[Union[MuxedAccount, str]] = None
+        self,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`EndSponsoringFutureReserves <stellar_sdk.operation.EndSponsoringFutureReserves>`
         operation to the list of operations.
@@ -962,7 +968,9 @@ class TransactionBuilder:
         return self.append_operation(op)
 
     def append_revoke_account_sponsorship_op(
-        self, account_id: str, source: Optional[Union[MuxedAccount, str]] = None
+        self,
+        account_id: str,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`RevokeSponsorship <stellar_sdk.operation.RevokeSponsorship>` operation
         for an account to the list of operations.
@@ -977,8 +985,8 @@ class TransactionBuilder:
     def append_revoke_trustline_sponsorship_op(
         self,
         account_id: str,
-        asset: Union[Asset, LiquidityPoolId],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        asset: Asset | LiquidityPoolId,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`RevokeSponsorship <stellar_sdk.operation.RevokeSponsorship>` operation
         for a trustline to the list of operations.
@@ -995,7 +1003,7 @@ class TransactionBuilder:
         self,
         seller_id: str,
         offer_id: int,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`RevokeSponsorship <stellar_sdk.operation.RevokeSponsorship>` operation
         for an offer to the list of operations.
@@ -1012,7 +1020,7 @@ class TransactionBuilder:
         self,
         account_id: str,
         data_name: str,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`RevokeSponsorship <stellar_sdk.operation.RevokeSponsorship>` operation
         for a data entry to the list of operations.
@@ -1028,7 +1036,7 @@ class TransactionBuilder:
     def append_revoke_claimable_balance_sponsorship_op(
         self,
         claimable_balance_id: str,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`RevokeSponsorship <stellar_sdk.operation.RevokeSponsorship>` operation
         for a claimable to the list of operations.
@@ -1045,7 +1053,7 @@ class TransactionBuilder:
     def append_revoke_liquidity_pool_sponsorship_op(
         self,
         liquidity_pool_id: str,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`RevokeSponsorship <stellar_sdk.operation.RevokeSponsorship>` operation
         for a claimable to the list of operations.
@@ -1063,7 +1071,7 @@ class TransactionBuilder:
         self,
         account_id: str,
         signer_key: str,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`RevokeSponsorship <stellar_sdk.operation.RevokeSponsorship>` operation
         for an ed25519_public_key signer to the list of operations.
@@ -1081,8 +1089,8 @@ class TransactionBuilder:
     def append_revoke_hashx_signer_sponsorship_op(
         self,
         account_id: str,
-        signer_key: Union[bytes, str],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        signer_key: bytes | str,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`RevokeSponsorship <stellar_sdk.operation.RevokeSponsorship>` operation
         for a hashx signer to the list of operations.
@@ -1103,8 +1111,8 @@ class TransactionBuilder:
     def append_revoke_pre_auth_tx_signer_sponsorship_op(
         self,
         account_id: str,
-        signer_key: Union[bytes, str],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        signer_key: bytes | str,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append a :class:`RevokeSponsorship <stellar_sdk.operation.RevokeSponsorship>` operation
         for a pre_auth_tx signer to the list of operations.
@@ -1125,9 +1133,9 @@ class TransactionBuilder:
     def append_clawback_op(
         self,
         asset: Asset,
-        from_: Union[MuxedAccount, str],
-        amount: Union[str, Decimal],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        from_: MuxedAccount | str,
+        amount: str | Decimal,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`Clawback <stellar_sdk.operation.Clawback>`
         operation to the list of operations.
@@ -1142,7 +1150,9 @@ class TransactionBuilder:
         return self.append_operation(op)
 
     def append_clawback_claimable_balance_op(
-        self, balance_id: str, source: Optional[Union[MuxedAccount, str]] = None
+        self,
+        balance_id: str,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`ClawbackClaimableBalance <stellar_sdk.operation.ClawbackClaimableBalance>`
         operation to the list of operations.
@@ -1159,9 +1169,9 @@ class TransactionBuilder:
         self,
         trustor: str,
         asset: Asset,
-        clear_flags: Optional[TrustLineFlags] = None,
-        set_flags: Optional[TrustLineFlags] = None,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        clear_flags: TrustLineFlags | None = None,
+        set_flags: TrustLineFlags | None = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`SetTrustLineFlags <stellar_sdk.operation.SetTrustLineFlags>`
         operation to the list of operations.
@@ -1180,11 +1190,11 @@ class TransactionBuilder:
     def append_liquidity_pool_deposit_op(
         self,
         liquidity_pool_id: str,
-        max_amount_a: Union[str, Decimal],
-        max_amount_b: Union[str, Decimal],
-        min_price: Union[str, Decimal, Price],
-        max_price: Union[str, Decimal, Price],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        max_amount_a: str | Decimal,
+        max_amount_b: str | Decimal,
+        min_price: str | Decimal | Price,
+        max_price: str | Decimal | Price,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`LiquidityPoolDeposit <stellar_sdk.operation.LiquidityPoolDeposit>`
         operation to the list of operations.
@@ -1206,10 +1216,10 @@ class TransactionBuilder:
     def append_liquidity_pool_withdraw_op(
         self,
         liquidity_pool_id: str,
-        amount: Union[str, Decimal],
-        min_amount_a: Union[str, Decimal],
-        min_amount_b: Union[str, Decimal],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        amount: str | Decimal,
+        min_amount_a: str | Decimal,
+        min_amount_b: str | Decimal,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`LiquidityPoolWithdraw <stellar_sdk.operation.LiquidityPoolWithdraw>`
         operation to the list of operations.
@@ -1231,9 +1241,9 @@ class TransactionBuilder:
         self,
         contract_id: str,
         function_name: str,
-        parameters: Optional[Sequence[stellar_xdr.SCVal]] = None,
-        auth: Optional[Sequence[stellar_xdr.SorobanAuthorizationEntry]] = None,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        parameters: Sequence[stellar_xdr.SCVal] | None = None,
+        auth: Sequence[stellar_xdr.SorobanAuthorizationEntry] | None = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`InvokeHostFunction <stellar_sdk.operation.InvokeHostFunction>` operation to the list of operations.
 
@@ -1268,8 +1278,8 @@ class TransactionBuilder:
 
     def append_upload_contract_wasm_op(
         self,
-        contract: Union[bytes, str],
-        source: Optional[Union[MuxedAccount, str]] = None,
+        contract: bytes | str,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`InvokeHostFunction <stellar_sdk.operation.InvokeHostFunction>` operation to the list of operations.
 
@@ -1295,12 +1305,12 @@ class TransactionBuilder:
 
     def append_create_contract_op(
         self,
-        wasm_id: Union[bytes, str],
-        address: Union[str, Address],
-        constructor_args: Optional[Sequence[stellar_xdr.SCVal]] = None,
-        salt: Optional[bytes] = None,
-        auth: Optional[Sequence[stellar_xdr.SorobanAuthorizationEntry]] = None,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        wasm_id: bytes | str,
+        address: str | Address,
+        constructor_args: Sequence[stellar_xdr.SCVal] | None = None,
+        salt: bytes | None = None,
+        auth: Sequence[stellar_xdr.SorobanAuthorizationEntry] | None = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`InvokeHostFunction <stellar_sdk.operation.InvokeHostFunction>` operation to the list of operations.
 
@@ -1355,7 +1365,7 @@ class TransactionBuilder:
     def append_create_stellar_asset_contract_from_asset_op(
         self,
         asset: Asset,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`InvokeHostFunction <stellar_sdk.operation.InvokeHostFunction>` operation to the list of operations.
 
@@ -1388,10 +1398,10 @@ class TransactionBuilder:
 
     def append_create_stellar_asset_contract_from_address_op(
         self,
-        address: Union[str, Address],
-        salt: Optional[bytes] = None,
-        auth: Optional[Sequence[stellar_xdr.SorobanAuthorizationEntry]] = None,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        address: str | Address,
+        salt: bytes | None = None,
+        auth: Sequence[stellar_xdr.SorobanAuthorizationEntry] | None = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`InvokeHostFunction <stellar_sdk.operation.InvokeHostFunction>` operation to the list of operations.
 
@@ -1438,7 +1448,9 @@ class TransactionBuilder:
         return self.append_operation(op)
 
     def append_extend_footprint_ttl_op(
-        self, extend_to: int, source: Optional[Union[MuxedAccount, str]] = None
+        self,
+        extend_to: int,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`ExtendFootprintTTL <stellar_sdk.operation.ExtendFootprintTTL>` operation to the list of operations.
 
@@ -1452,7 +1464,8 @@ class TransactionBuilder:
         return self.append_operation(op)
 
     def append_restore_footprint_op(
-        self, source: Optional[Union[MuxedAccount, str]] = None
+        self,
+        source: MuxedAccount | str | None = None,
     ):
         """Append an :class:`RestoreFootprint <stellar_sdk.operation.RestoreFootprint>` operation to the list of operations.
 
@@ -1467,12 +1480,12 @@ class TransactionBuilder:
         self,
         destination: str,
         asset: Asset,
-        amount: Union[str, Decimal],
+        amount: str | Decimal,
         instructions: int = 400_000,
         disk_read_bytes: int = 1_000,
         write_bytes: int = 1_000,
         resource_fee: int = 5_000_000,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`InvokeHostFunction <stellar_sdk.operation.InvokeHostFunction>` operation to send assets to a contract address.
 
@@ -1638,7 +1651,7 @@ class TransactionBuilder:
         disk_read_bytes: int = 500,
         write_bytes: int = 500,
         resource_fee: int = 4_000_000,
-        source: Optional[Union[MuxedAccount, str]] = None,
+        source: MuxedAccount | str | None = None,
     ) -> "TransactionBuilder":
         """Append an :class:`RestoreFootprint <stellar_sdk.operation.RestoreFootprint>` operation to restore the asset balance entry.
 

--- a/stellar_sdk/transaction_envelope.py
+++ b/stellar_sdk/transaction_envelope.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Optional, Sequence, Union
+from collections.abc import Sequence
 
 from xdrlib3 import Packer
 
@@ -34,7 +34,7 @@ class TransactionEnvelope(BaseTransactionEnvelope["TransactionEnvelope"]):
         self,
         transaction: Transaction,
         network_passphrase: str,
-        signatures: Optional[Sequence[DecoratedSignature]] = None,
+        signatures: Sequence[DecoratedSignature] | None = None,
     ) -> None:
         super().__init__(network_passphrase, signatures)
         self.transaction: Transaction = transaction
@@ -62,7 +62,7 @@ class TransactionEnvelope(BaseTransactionEnvelope["TransactionEnvelope"]):
         tx.to_xdr_object().pack(packer)
         return network_id + packer.get_buffer()
 
-    def sign_extra_signers_payload(self, signer: Union[Keypair, str]) -> None:
+    def sign_extra_signers_payload(self, signer: Keypair | str) -> None:
         """Sign this extra signers' payload with a given keypair.
 
         Note that the signature must not already be in this instance's list of

--- a/stellar_sdk/utils.py
+++ b/stellar_sdk/utils.py
@@ -4,8 +4,9 @@ They may change at any time, so please do not use them directly.
 
 import hashlib
 import re
+from collections.abc import Sequence
 from decimal import ROUND_FLOOR, Context, Decimal, Inexact
-from typing import TYPE_CHECKING, Dict, Optional, Sequence, Union
+from typing import TYPE_CHECKING
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
 from .exceptions import Ed25519PublicKeyInvalidError, NoApproximationError
@@ -26,7 +27,7 @@ def sha256(data: bytes) -> bytes:
     return hashlib.sha256(data).digest()
 
 
-def best_rational_approximation(x) -> Dict[str, int]:
+def best_rational_approximation(x) -> dict[str, int]:
     x = Decimal(x)
     int32_max = Decimal(2147483647)
     fractions = [[Decimal(0), Decimal(1)], [Decimal(1), Decimal(0)]]
@@ -52,7 +53,7 @@ def best_rational_approximation(x) -> Dict[str, int]:
     return {"n": int(n), "d": int(d)}
 
 
-def hex_to_bytes(hex_string: Union[str, bytes]) -> bytes:
+def hex_to_bytes(hex_string: str | bytes) -> bytes:
     if isinstance(hex_string, str):
         return bytes.fromhex(hex_string)
     return hex_string
@@ -68,7 +69,7 @@ def convert_assets_to_horizon_param(assets: Sequence["Asset"]) -> str:
     return ",".join(assets_string)
 
 
-def urljoin_with_query(base: str, path: Optional[str]) -> str:
+def urljoin_with_query(base: str, path: str | None) -> str:
     split_url = urlsplit(base)
     query = split_url.query
     real_path = split_url.path
@@ -126,7 +127,7 @@ def raise_if_not_valid_balance_id(value: str, argument_name: str) -> None:
         )
 
 
-def to_xdr_amount(value: Union[str, Decimal]) -> int:
+def to_xdr_amount(value: str | Decimal) -> int:
     """Converts an amount to the appropriate value to send over the network
     as a part of an XDR object.
 

--- a/tests/operation/test_extend_footprint_ttl.py
+++ b/tests/operation/test_extend_footprint_ttl.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import pytest
 
 from stellar_sdk import Operation
@@ -38,7 +36,7 @@ class TestExtendFootprintTTL:
     def test_xdr(
         self,
         extend_to: int,
-        source: Optional[Union[MuxedAccount, str]],
+        source: MuxedAccount | str | None,
         xdr: str,
     ):
         op = ExtendFootprintTTL(extend_to, source)

--- a/tests/operation/test_restore_footprint.py
+++ b/tests/operation/test_restore_footprint.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import pytest
 
 from stellar_sdk import Operation
@@ -20,7 +18,7 @@ class TestRestoreFootprint:
             ),
         ],
     )
-    def test_xdr(self, source: Optional[Union[MuxedAccount, str]], xdr: str):
+    def test_xdr(self, source: MuxedAccount | str | None, xdr: str):
         op = RestoreFootprint(source)
         check_source(op.source, source)
         xdr_object = op.to_xdr_object()

--- a/tests/test_soroban_server_async.py
+++ b/tests/test_soroban_server_async.py
@@ -1294,8 +1294,8 @@ class TestSorobanServer:
 
 
 def _build_soroban_transaction(
-    soroban_data: Optional[stellar_xdr.SorobanTransactionData],
-    auth: List[stellar_xdr.SorobanAuthorizationEntry],
+    soroban_data: stellar_xdr.SorobanTransactionData | None,
+    auth: list[stellar_xdr.SorobanAuthorizationEntry],
 ):
     contract_id = (
         "CDU3PZ4LXVETIFVLS33RDXLD63JZ5GXS7PCV2DJ7BBT6EBPA2AB7YR5H"  # auth contract

--- a/tests/test_soroban_server_sync.py
+++ b/tests/test_soroban_server_sync.py
@@ -1302,8 +1302,8 @@ class TestSorobanServer:
 
 
 def _build_soroban_transaction(
-    soroban_data: Optional[stellar_xdr.SorobanTransactionData],
-    auth: List[stellar_xdr.SorobanAuthorizationEntry],
+    soroban_data: stellar_xdr.SorobanTransactionData | None,
+    auth: list[stellar_xdr.SorobanAuthorizationEntry],
 ):
     contract_id = (
         "CDU3PZ4LXVETIFVLS33RDXLD63JZ5GXS7PCV2DJ7BBT6EBPA2AB7YR5H"  # auth contract

--- a/tests/test_transaction_builder.py
+++ b/tests/test_transaction_builder.py
@@ -1,6 +1,5 @@
 import binascii
 import time
-from typing import Optional
 
 import pytest
 
@@ -53,11 +52,11 @@ asset3 = Asset("PANDA", "GDJVFDG5OCW5PYWHB64MGTHGFF57DRRJEDUEFDEL2SLNIOONHYJWHA3
 
 
 def get_tx_builder(
-    source_account: Optional[Account] = None,
+    source_account: Account | None = None,
     base_fee: int = 100,
     network_passphrase: str = Network.TESTNET_NETWORK_PASSPHRASE,
-    min_time: Optional[int] = 1600000000,
-    max_time: Optional[int] = 1700000000,
+    min_time: int | None = 1600000000,
+    max_time: int | None = 1700000000,
     v1: bool = True,
 ) -> TransactionBuilder:
     if source_account is None:


### PR DESCRIPTION
This PR also includes the new type hinting syntax introduced in Python 3.10, and support for Python 3.10 is about to end, so let's wait until it ends before merging this PR.

https://endoflife.date/python