### PR TITLE
Handle non-JSON RPC responses

### DIFF
--- a/stellar_sdk/soroban_server.py
+++ b/stellar_sdk/soroban_server.py
@@ -22,6 +22,7 @@ from .exceptions import (
     AccountNotFoundException,
     PrepareTransactionException,
     SorobanRpcErrorResponse,
+    raise_request_exception,
 )
 from .keypair import Keypair
 from .soroban_rpc import *
@@ -70,6 +71,7 @@ class SorobanServer:
 
         :return: A :class:`GetHealthResponse <stellar_sdk.soroban_rpc.GetHealthResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request: Request = Request(
             id=_generate_unique_request_id(),
@@ -97,6 +99,7 @@ class SorobanServer:
         :param limit: The maximum number of records to return.
         :return: A :class:`GetEventsResponse <stellar_sdk.soroban_rpc.GetEventsResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         pagination = PaginationOptions(cursor=cursor, limit=limit)
         data = GetEventsRequest(
@@ -117,6 +120,7 @@ class SorobanServer:
 
         :return: A :class:`GetNetworkResponse <stellar_sdk.soroban_rpc.GetNetworkResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request: Request = Request(
             id=_generate_unique_request_id(),
@@ -132,6 +136,7 @@ class SorobanServer:
 
         :return: A :class:`GetLatestLedgerResponse <stellar_sdk.soroban_rpc.GetLatestLedgerResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request: Request = Request(
             id=_generate_unique_request_id(),
@@ -154,6 +159,7 @@ class SorobanServer:
         :param keys: The ledger keys to fetch.
         :return: A :class:`GetLedgerEntriesResponse <stellar_sdk.soroban_rpc.GetLedgerEntriesResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request = Request[GetLedgerEntriesRequest](
             id=_generate_unique_request_id(),
@@ -170,6 +176,7 @@ class SorobanServer:
         :param transaction_hash: The hash of the transaction to fetch.
         :return: A :class:`GetTransactionResponse <stellar_sdk.soroban_rpc.GetTransactionResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request = Request[GetTransactionRequest](
             id=_generate_unique_request_id(),
@@ -197,6 +204,8 @@ class SorobanServer:
         :param auth_mode: Explicitly allows users to opt-in to non-root authorization in recording mode.
         :return: A :class:`SimulateTransactionResponse <stellar_sdk.soroban_rpc.SimulateTransactionResponse>` object
             contains the cost, footprint, result/auth requirements (if applicable), and error of the transaction.
+        :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         xdr = (
             transaction_envelope
@@ -229,6 +238,7 @@ class SorobanServer:
         :param transaction_envelope: The transaction to send.
         :return: A :class:`SendTransactionResponse <stellar_sdk.soroban_rpc.SendTransactionResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         xdr = (
             transaction_envelope
@@ -257,6 +267,7 @@ class SorobanServer:
         :param sleep_strategy: The amount of time to wait for between each attempt, defaults to 1 second between each attempt.
         :return: A :class:`GetTransactionResponse <stellar_sdk.soroban_rpc.GetTransactionResponse>` response object after a "found" response, (which may be success or failure) or the last response obtained after polling the maximum number of specified attempts.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         if max_attempts < 1:
             raise ValueError("max_attempts must be greater than 0")
@@ -280,6 +291,7 @@ class SorobanServer:
 
         :return: A :class:`GetFeeStatsResponse <stellar_sdk.soroban_rpc.GetFeeStatsResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request: Request = Request(
             id=_generate_unique_request_id(),
@@ -304,6 +316,7 @@ class SorobanServer:
         :param limit: The maximum number of records to return.
         :return: A :class:`GetTransactionsResponse <stellar_sdk.soroban_rpc.GetTransactionsResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         pagination = PaginationOptions(cursor=cursor, limit=limit)
         data = GetTransactionsRequest(
@@ -331,6 +344,7 @@ class SorobanServer:
         :param limit: The maximum number of records to return.
         :return: A :class:`GetLedgersResponse <stellar_sdk.soroban_rpc.GetLedgersResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         pagination = PaginationOptions(cursor=cursor, limit=limit)
         data = GetLedgersRequest(
@@ -350,6 +364,7 @@ class SorobanServer:
         :return: An :class:`Account <stellar_sdk.account.Account>` object.
         :raises: :exc:`AccountNotFoundException <stellar_sdk.exceptions.AccountNotFoundException>` - If the account is not found on the network.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         account_id_xdr = Keypair.from_public_key(account_id).xdr_account_id()
         key = stellar_xdr.LedgerKey(
@@ -380,6 +395,7 @@ class SorobanServer:
             :class:`Durability.TEMPORARY` or :class:`Durability.PERSISTENT`. Defaults to :class:`Durability.PERSISTENT`.
         :return: A :class:`LedgerEntryResult <stellar_sdk.soroban_rpc.LedgerEntryResult>` object contains the ledger entry result or ``None`` if not found.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         sc_address = Address(contract_id).to_xdr_sc_address()
         xdr_durability = (
@@ -408,6 +424,7 @@ class SorobanServer:
 
         :return: A :class:`GetVersionInfoResponse <stellar_sdk.soroban_rpc.GetVersionInfoResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request: Request = Request(
             id=_generate_unique_request_id(),
@@ -533,7 +550,12 @@ class SorobanServer:
             self.server_url,
             json_data=json.loads(json_data),
         )
-        raw_response = Response[Any].model_validate(data.json())
+        try:
+            raw_response = Response[Any].model_validate(data.json())
+        except json.JSONDecodeError as exc:
+            raise_request_exception(data)
+            # in practice the above should always raise and the re-raise is to please type checkers
+            raise exc
 
         if raw_response.error:
             raise SorobanRpcErrorResponse(

--- a/stellar_sdk/soroban_server_async.py
+++ b/stellar_sdk/soroban_server_async.py
@@ -22,6 +22,7 @@ from .exceptions import (
     AccountNotFoundException,
     PrepareTransactionException,
     SorobanRpcErrorResponse,
+    raise_request_exception,
 )
 from .keypair import Keypair
 from .soroban_rpc import *
@@ -70,6 +71,7 @@ class SorobanServerAsync:
 
         :return: A :class:`GetHealthResponse <stellar_sdk.soroban_rpc.GetHealthResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request: Request = Request(
             id=_generate_unique_request_id(),
@@ -97,6 +99,7 @@ class SorobanServerAsync:
         :param limit: The maximum number of records to return.
         :return: A :class:`GetEventsResponse <stellar_sdk.soroban_rpc.GetEventsResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         pagination = PaginationOptions(cursor=cursor, limit=limit)
         data = GetEventsRequest(
@@ -117,6 +120,7 @@ class SorobanServerAsync:
 
         :return: A :class:`GetNetworkResponse <stellar_sdk.soroban_rpc.GetNetworkResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request: Request = Request(
             id=_generate_unique_request_id(),
@@ -132,6 +136,7 @@ class SorobanServerAsync:
 
         :return: A :class:`GetLatestLedgerResponse <stellar_sdk.soroban_rpc.GetLatestLedgerResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request: Request = Request(
             id=_generate_unique_request_id(),
@@ -154,6 +159,7 @@ class SorobanServerAsync:
         :param keys: The ledger keys to fetch.
         :return: A :class:`GetLedgerEntriesResponse <stellar_sdk.soroban_rpc.GetLedgerEntriesResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request = Request[GetLedgerEntriesRequest](
             id=_generate_unique_request_id(),
@@ -170,6 +176,7 @@ class SorobanServerAsync:
         :param transaction_hash: The hash of the transaction to fetch.
         :return: A :class:`GetTransactionResponse <stellar_sdk.soroban_rpc.GetTransactionResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request = Request[GetTransactionRequest](
             id=_generate_unique_request_id(),
@@ -197,6 +204,8 @@ class SorobanServerAsync:
         :param auth_mode: Explicitly allows users to opt-in to non-root authorization in recording mode.
         :return: A :class:`SimulateTransactionResponse <stellar_sdk.soroban_rpc.SimulateTransactionResponse>` object
             contains the cost, footprint, result/auth requirements (if applicable), and error of the transaction.
+        :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         xdr = (
             transaction_envelope
@@ -228,6 +237,7 @@ class SorobanServerAsync:
         :param transaction_envelope: The transaction to send.
         :return: A :class:`SendTransactionResponse <stellar_sdk.soroban_rpc.SendTransactionResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         xdr = (
             transaction_envelope
@@ -256,6 +266,7 @@ class SorobanServerAsync:
         :param sleep_strategy: The amount of time to wait for between each attempt, defaults to 1 second between each attempt.
         :return: A :class:`GetTransactionResponse <stellar_sdk.soroban_rpc.GetTransactionResponse>` response object after a "found" response, (which may be success or failure) or the last response obtained after polling the maximum number of specified attempts.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         if max_attempts < 1:
             raise ValueError("max_attempts must be greater than 0")
@@ -279,6 +290,7 @@ class SorobanServerAsync:
 
         :return: A :class:`GetFeeStatsResponse <stellar_sdk.soroban_rpc.GetFeeStatsResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request: Request = Request(
             id=_generate_unique_request_id(),
@@ -303,6 +315,7 @@ class SorobanServerAsync:
         :param limit: The maximum number of records to return.
         :return: A :class:`GetTransactionsResponse <stellar_sdk.soroban_rpc.GetTransactionsResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         pagination = PaginationOptions(cursor=cursor, limit=limit)
         data = GetTransactionsRequest(
@@ -330,6 +343,7 @@ class SorobanServerAsync:
         :param limit: The maximum number of records to return.
         :return: A :class:`GetLedgersResponse <stellar_sdk.soroban_rpc.GetLedgersResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         pagination = PaginationOptions(cursor=cursor, limit=limit)
         data = GetLedgersRequest(
@@ -349,6 +363,7 @@ class SorobanServerAsync:
         :return: An :class:`Account <stellar_sdk.account.Account>` object.
         :raises: :exc:`AccountNotFoundException <stellar_sdk.exceptions.AccountNotFoundException>` - If the account is not found on the network.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         account_id_xdr = Keypair.from_public_key(account_id).xdr_account_id()
         key = stellar_xdr.LedgerKey(
@@ -379,6 +394,7 @@ class SorobanServerAsync:
             :class:`Durability.TEMPORARY` or :class:`Durability.PERSISTENT`. Defaults to :class:`Durability.PERSISTENT`.
         :return: A :class:`LedgerEntryResult <stellar_sdk.soroban_rpc.LedgerEntryResult>` object contains the ledger entry result or ``None`` if not found.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         sc_address = Address(contract_id).to_xdr_sc_address()
         xdr_durability = (
@@ -407,6 +423,7 @@ class SorobanServerAsync:
 
         :return: A :class:`GetVersionInfoResponse <stellar_sdk.soroban_rpc.GetVersionInfoResponse>` object.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
+        :raises: :exc:`BadResponseError <stellar_sdk.exceptions.BadResponseError>` - If a non-JSON error response is returned, possibly by a CDN or reverse proxy.
         """
         request: Request = Request(
             id=_generate_unique_request_id(),
@@ -528,7 +545,13 @@ class SorobanServerAsync:
             self.server_url,
             json_data=json.loads(json_data),
         )
-        raw_response = Response[Any].model_validate(data.json())
+        try:
+            raw_response = Response[Any].model_validate(data.json())
+        except json.JSONDecodeError as exc:
+            raise_request_exception(data)
+            # in practice the above should always raise and the re-raise is to please type checkers
+            raise exc
+
         if raw_response.error:
             raise SorobanRpcErrorResponse(
                 raw_response.error.code,

--- a/tests/test_soroban_server_async.py
+++ b/tests/test_soroban_server_async.py
@@ -11,6 +11,7 @@ from stellar_sdk.address import Address
 from stellar_sdk.base_soroban_server import ResourceLeeway
 from stellar_sdk.exceptions import (
     AccountNotFoundException,
+    BadResponseError,
     PrepareTransactionException,
     SorobanRpcErrorResponse,
 )
@@ -1268,6 +1269,14 @@ class TestSorobanServer:
         val_error = e.value.errors()[0]
         assert val_error["type"] == "value_error"
         assert val_error["msg"].endswith("end_ledger and cursor cannot both be set")
+
+    async def test_non_json_response(self):
+        with aioresponses() as m:
+            m.post(RPC_URL, status=500, body="Cloudflare 500 error")
+
+            with pytest.raises(BadResponseError):
+                async with SorobanServerAsync(RPC_URL) as client:
+                    await client.get_health()
 
 
 def _build_soroban_transaction(

--- a/tests/test_soroban_server_sync.py
+++ b/tests/test_soroban_server_sync.py
@@ -11,6 +11,7 @@ from stellar_sdk.address import Address
 from stellar_sdk.base_soroban_server import ResourceLeeway
 from stellar_sdk.exceptions import (
     AccountNotFoundException,
+    BadResponseError,
     PrepareTransactionException,
     SorobanRpcErrorResponse,
 )
@@ -1276,6 +1277,13 @@ class TestSorobanServer:
         val_error = e.value.errors()[0]
         assert val_error["type"] == "value_error"
         assert val_error["msg"].endswith("end_ledger and cursor cannot both be set")
+
+    def test_non_json_response(self):
+        with requests_mock.Mocker() as m:
+            m.post(RPC_URL, status_code=500, text="Cloudflare 500 error")
+
+            with pytest.raises(BadResponseError):
+                SorobanServer(RPC_URL).get_health()
 
 
 def _build_soroban_transaction(


### PR DESCRIPTION
The recent Cloudflare CDN outage revealed what happens if an RPC doesn't return a JSON-parseable body: a `JSONDecodeError`. This may be confusing for SDK users, and it obfuscates the actual error response sent by the server.

This PR handles the error with `raise_request_exception` in `SorobanServer` and `SorobanServerAsync`. I was tempted to handle the error directly in the `Response` class, but the `raise_request_exception` pattern is already so ubiquitous throughout this codebase that it looked neater to just apply it to these two client classes.