### PR TITLE
Revert "feat: add simulateTransaction authV2 flag (#1188)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ Release History
   - `AssembledTransaction`: `sign_auth_entries` and `needs_non_invoker_signing_by` (and the async variants) handle all address-based credential types; V2 entries previously crashed with `AssertionError`.
   - SEP-45 (`stellar_sdk.sep.stellar_soroban_web_authentication`): challenge parsing and building accept `ADDRESS_V2` entries in addition to the legacy type; delegated entries are rejected.
 - chore: upgrade generated XDR definitions to Protocol 27.
-- feat: add `auth_v2` support to `SorobanServer[Async].simulate_transaction` and contract clients to request `ADDRESS_V2` auth entries. Enable it only when targeting Protocol 27 RPC behavior and callers need V2 auth entries; older RPC servers may silently ignore the flag and return legacy `ADDRESS` credentials.
 
 ### Version 14.1.0
 

--- a/stellar_sdk/contract/assembled_transaction.py
+++ b/stellar_sdk/contract/assembled_transaction.py
@@ -55,10 +55,6 @@ class AssembledTransaction(Generic[T]):
     :param auth_mode: Authorization mode forwarded to every internal simulation
         call. Use :class:`AuthMode.RECORD_ALL_NOROOT <stellar_sdk.soroban_rpc.AuthMode>`
         to opt into non-root authorization in recording mode.
-    :param auth_v2: Whether internal simulation calls should request
-        ``ADDRESS_V2`` credentials in returned auth entries. Set to ``True``
-        when targeting Protocol 27 RPC behavior and V2 auth entries
-        are required.
     """
 
     def __init__(
@@ -70,7 +66,6 @@ class AssembledTransaction(Generic[T]):
         submit_timeout: int = 180,
         addl_resources: ResourceLeeway | None = None,
         auth_mode: AuthMode | None = None,
-        auth_v2: bool = False,
     ):
         self.server = server
         self.submit_timeout = submit_timeout
@@ -83,7 +78,6 @@ class AssembledTransaction(Generic[T]):
 
         self.addl_resources = addl_resources
         self.auth_mode = auth_mode
-        self.auth_v2 = auth_v2
 
         self.simulation: SimulateTransactionResponse | None = None
         self._simulation_result: SimulateHostFunctionResult | None = None
@@ -118,7 +112,6 @@ class AssembledTransaction(Generic[T]):
             built_tx,
             addl_resources=self.addl_resources,
             auth_mode=self.auth_mode,
-            auth_v2=self.auth_v2,
         )
 
         if (
@@ -179,7 +172,6 @@ class AssembledTransaction(Generic[T]):
             simulation_tx,
             addl_resources=self.addl_resources,
             auth_mode=self.auth_mode,
-            auth_v2=self.auth_v2,
         )
         self._simulation_result = None
         self._simulation_transaction_data = None

--- a/stellar_sdk/contract/assembled_transaction_async.py
+++ b/stellar_sdk/contract/assembled_transaction_async.py
@@ -62,10 +62,6 @@ class AssembledTransactionAsync(Generic[T]):
     :param auth_mode: Authorization mode forwarded to every internal simulation
         call. Use :class:`AuthMode.RECORD_ALL_NOROOT <stellar_sdk.soroban_rpc.AuthMode>`
         to opt into non-root authorization in recording mode.
-    :param auth_v2: Whether internal simulation calls should request
-        ``ADDRESS_V2`` credentials in returned auth entries. Set to ``True``
-        when targeting Protocol 27 RPC behavior and V2 auth entries
-        are required.
     """
 
     def __init__(
@@ -77,7 +73,6 @@ class AssembledTransactionAsync(Generic[T]):
         submit_timeout: int = 180,
         addl_resources: ResourceLeeway | None = None,
         auth_mode: AuthMode | None = None,
-        auth_v2: bool = False,
     ):
         self.server = server
         self.submit_timeout = submit_timeout
@@ -90,7 +85,6 @@ class AssembledTransactionAsync(Generic[T]):
 
         self.addl_resources = addl_resources
         self.auth_mode = auth_mode
-        self.auth_v2 = auth_v2
 
         self.simulation: SimulateTransactionResponse | None = None
         self._simulation_result: SimulateHostFunctionResult | None = None
@@ -125,7 +119,6 @@ class AssembledTransactionAsync(Generic[T]):
             built_tx,
             addl_resources=self.addl_resources,
             auth_mode=self.auth_mode,
-            auth_v2=self.auth_v2,
         )
 
         if (
@@ -186,7 +179,6 @@ class AssembledTransactionAsync(Generic[T]):
             simulation_tx,
             addl_resources=self.addl_resources,
             auth_mode=self.auth_mode,
-            auth_v2=self.auth_v2,
         )
         self._simulation_result = None
         self._simulation_transaction_data = None

--- a/stellar_sdk/contract/contract_client.py
+++ b/stellar_sdk/contract/contract_client.py
@@ -58,7 +58,6 @@ class ContractClient:
         restore: bool = True,
         addl_resources: ResourceLeeway | None = None,
         auth_mode: AuthMode | None = None,
-        auth_v2: bool = False,
     ) -> AssembledTransaction[T]:
         """Build an :py:class:`AssembledTransaction <stellar_sdk.contract.AssembledTransaction>` to invoke a contract function.
 
@@ -74,7 +73,6 @@ class ContractClient:
         :param restore: Whether to restore the transaction, only valid when simulate is True, and the signer is provided.
         :param addl_resources: Additional resource leeway forwarded to every simulation performed by the returned :class:`AssembledTransaction <stellar_sdk.contract.AssembledTransaction>`.
         :param auth_mode: Authorization mode forwarded to every simulation performed by the returned :class:`AssembledTransaction <stellar_sdk.contract.AssembledTransaction>`.
-        :param auth_v2: Whether simulations performed by the returned :class:`AssembledTransaction <stellar_sdk.contract.AssembledTransaction>` should request ``ADDRESS_V2`` credentials in returned auth entries. Set to ``True`` when targeting Protocol 27 RPC behavior and V2 auth entries are required.
         :return:
         """
         builder = (
@@ -94,7 +92,6 @@ class ContractClient:
             submit_timeout,
             addl_resources=addl_resources,
             auth_mode=auth_mode,
-            auth_v2=auth_v2,
         )
         if simulate:
             assembled = assembled.simulate(restore)

--- a/stellar_sdk/contract/contract_client_async.py
+++ b/stellar_sdk/contract/contract_client_async.py
@@ -57,7 +57,6 @@ class ContractClientAsync:
         restore: bool = True,
         addl_resources: ResourceLeeway | None = None,
         auth_mode: AuthMode | None = None,
-        auth_v2: bool = False,
     ) -> AssembledTransactionAsync[T]:
         """Build an :py:class:`AssembledTransactionAsync <stellar_sdk.contract.AssembledTransactionAsync>` to invoke a contract function.
 
@@ -73,7 +72,6 @@ class ContractClientAsync:
         :param restore: Whether to restore the transaction, only valid when simulate is True, and the signer is provided.
         :param addl_resources: Additional resource leeway forwarded to every simulation performed by the returned :class:`AssembledTransactionAsync <stellar_sdk.contract.AssembledTransactionAsync>`.
         :param auth_mode: Authorization mode forwarded to every simulation performed by the returned :class:`AssembledTransactionAsync <stellar_sdk.contract.AssembledTransactionAsync>`.
-        :param auth_v2: Whether simulations performed by the returned :class:`AssembledTransactionAsync <stellar_sdk.contract.AssembledTransactionAsync>` should request ``ADDRESS_V2`` credentials in returned auth entries. Set to ``True`` when targeting Protocol 27 RPC behavior and V2 auth entries are required.
         :return:
         """
         builder = (
@@ -93,7 +91,6 @@ class ContractClientAsync:
             submit_timeout,
             addl_resources=addl_resources,
             auth_mode=auth_mode,
-            auth_v2=auth_v2,
         )
         if simulate:
             assembled = await assembled.simulate(restore)

--- a/stellar_sdk/soroban_rpc.py
+++ b/stellar_sdk/soroban_rpc.py
@@ -207,7 +207,6 @@ class SimulateTransactionRequest(BaseModel):
     transaction: str
     resource_config: ResourceConfig | None = Field(alias="resourceConfig", default=None)
     auth_mode: AuthMode | None = Field(alias="authMode", default=None)
-    auth_v2: bool = Field(alias="authV2", default=False)
     model_config = ConfigDict(populate_by_name=True)
 
 

--- a/stellar_sdk/soroban_server.py
+++ b/stellar_sdk/soroban_server.py
@@ -199,7 +199,6 @@ class SorobanServer:
         transaction_envelope: TransactionEnvelope,
         addl_resources: ResourceLeeway | None = None,
         auth_mode: AuthMode | None = None,
-        auth_v2: bool = False,
     ) -> SimulateTransactionResponse:
         """Submit a trial contract invocation to get back return values, expected ledger footprint, and expected costs.
 
@@ -212,7 +211,6 @@ class SorobanServer:
             Any provided footprint will be ignored.
         :param addl_resources: Additional resource include in the simulation.
         :param auth_mode: Explicitly allows users to opt-in to non-root authorization in recording mode.
-        :param auth_v2: Request ``ADDRESS_V2`` credentials instead of legacy ``ADDRESS`` credentials in returned auth entries. Set this to ``True`` when targeting Protocol 27 RPC behavior and callers need V2 auth entries. Older RPC servers may silently ignore this flag; inspect the returned credential arm to confirm the response type.
         :return: A :class:`SimulateTransactionResponse <stellar_sdk.soroban_rpc.SimulateTransactionResponse>` object
             contains the cost, footprint, result/auth requirements (if applicable), and error of the transaction.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
@@ -233,10 +231,7 @@ class SorobanServer:
             id=_generate_unique_request_id(),
             method="simulateTransaction",
             params=SimulateTransactionRequest(
-                transaction=xdr,
-                resourceConfig=resource_config,
-                authMode=auth_mode,
-                authV2=auth_v2,
+                transaction=xdr, resourceConfig=resource_config, authMode=auth_mode
             ),
         )
         return self._post(request, SimulateTransactionResponse)

--- a/stellar_sdk/soroban_server_async.py
+++ b/stellar_sdk/soroban_server_async.py
@@ -199,7 +199,6 @@ class SorobanServerAsync:
         transaction_envelope: TransactionEnvelope,
         addl_resources: ResourceLeeway | None = None,
         auth_mode: AuthMode | None = None,
-        auth_v2: bool = False,
     ) -> SimulateTransactionResponse:
         """Submit a trial contract invocation to get back return values, expected ledger footprint, and expected costs.
 
@@ -212,7 +211,6 @@ class SorobanServerAsync:
             Any provided footprint will be ignored.
         :param addl_resources: Additional resource include in the simulation.
         :param auth_mode: Explicitly allows users to opt-in to non-root authorization in recording mode.
-        :param auth_v2: Request ``ADDRESS_V2`` credentials instead of legacy ``ADDRESS`` credentials in returned auth entries. Set this to ``True`` when targeting Protocol 27 RPC behavior and callers need V2 auth entries. Older RPC servers may silently ignore this flag; inspect the returned credential arm to confirm the response type.
         :return: A :class:`SimulateTransactionResponse <stellar_sdk.soroban_rpc.SimulateTransactionResponse>` object
             contains the cost, footprint, result/auth requirements (if applicable), and error of the transaction.
         :raises: :exc:`SorobanRpcErrorResponse <stellar_sdk.exceptions.SorobanRpcErrorResponse>` - If the Soroban-RPC instance returns an error response.
@@ -232,10 +230,7 @@ class SorobanServerAsync:
             id=_generate_unique_request_id(),
             method="simulateTransaction",
             params=SimulateTransactionRequest(
-                transaction=xdr,
-                resourceConfig=resource_config,
-                authMode=auth_mode,
-                authV2=auth_v2,
+                transaction=xdr, resourceConfig=resource_config, authMode=auth_mode
             ),
         )
         return await self._post(request, SimulateTransactionResponse)

--- a/tests/contract/test_assembled_transaction.py
+++ b/tests/contract/test_assembled_transaction.py
@@ -85,7 +85,7 @@ class _FakeSorobanServer:
         return SimpleNamespace(sequence=100)
 
     def simulate_transaction(
-        self, transaction, addl_resources=None, auth_mode=None, auth_v2=False
+        self, transaction, addl_resources=None, auth_mode=None
     ) -> SimpleNamespace:
         self.simulated_transactions.append(transaction)
         restore_preamble = (
@@ -105,7 +105,7 @@ class _FakeSorobanServerAsync:
         return SimpleNamespace(sequence=100)
 
     async def simulate_transaction(
-        self, transaction, addl_resources=None, auth_mode=None, auth_v2=False
+        self, transaction, addl_resources=None, auth_mode=None
     ) -> SimpleNamespace:
         self.simulated_transactions.append(transaction)
         restore_preamble = (

--- a/tests/test_soroban_server_async.py
+++ b/tests/test_soroban_server_async.py
@@ -860,7 +860,6 @@ class TestSorobanServer:
             "transaction": transaction.to_xdr(),
             "resourceConfig": None,
             "authMode": None,
-            "authV2": False,
         }
 
     async def test_simulate_transaction_with_addl_resources(self):
@@ -904,7 +903,6 @@ class TestSorobanServer:
             "transaction": transaction.to_xdr(),
             "resourceConfig": {"instructionLeeway": 1000000},
             "authMode": None,
-            "authV2": False,
         }
 
     async def test_simulate_transaction_with_auth_mode(self):
@@ -956,59 +954,6 @@ class TestSorobanServer:
             "transaction": transaction.to_xdr(),
             "resourceConfig": None,
             "authMode": "record_allow_nonroot",
-            "authV2": False,
-        }
-
-    async def test_simulate_transaction_with_auth_v2(self):
-        result = {"latestLedger": 1479}
-        data = {
-            "jsonrpc": "2.0",
-            "id": "e1fabdcdf0244a2a9adfab94d7748b6c",
-            "result": result,
-        }
-        transaction = _build_soroban_transaction(None, [])
-        with aioresponses() as m:
-            m.post(RPC_URL, payload=data)
-            async with SorobanServerAsync(RPC_URL) as client:
-                assert (
-                    await client.simulate_transaction(transaction, auth_v2=True)
-                ) == SimulateTransactionResponse.model_validate(result)
-
-        request_data = m.requests[("POST", URL(RPC_URL))][0].kwargs["json"]
-        assert len(request_data["id"]) == 32
-        assert request_data["jsonrpc"] == "2.0"
-        assert request_data["method"] == "simulateTransaction"
-        assert request_data["params"] == {
-            "transaction": transaction.to_xdr(),
-            "resourceConfig": None,
-            "authMode": None,
-            "authV2": True,
-        }
-
-    async def test_simulate_transaction_with_auth_v2_false(self):
-        result = {"latestLedger": 1479}
-        data = {
-            "jsonrpc": "2.0",
-            "id": "e1fabdcdf0244a2a9adfab94d7748b6c",
-            "result": result,
-        }
-        transaction = _build_soroban_transaction(None, [])
-        with aioresponses() as m:
-            m.post(RPC_URL, payload=data)
-            async with SorobanServerAsync(RPC_URL) as client:
-                assert (
-                    await client.simulate_transaction(transaction, auth_v2=False)
-                ) == SimulateTransactionResponse.model_validate(result)
-
-        request_data = m.requests[("POST", URL(RPC_URL))][0].kwargs["json"]
-        assert len(request_data["id"]) == 32
-        assert request_data["jsonrpc"] == "2.0"
-        assert request_data["method"] == "simulateTransaction"
-        assert request_data["params"] == {
-            "transaction": transaction.to_xdr(),
-            "resourceConfig": None,
-            "authMode": None,
-            "authV2": False,
         }
 
     async def test_prepare_transaction_without_auth_and_soroban_data(self):

--- a/tests/test_soroban_server_sync.py
+++ b/tests/test_soroban_server_sync.py
@@ -888,7 +888,6 @@ class TestSorobanServer:
             "transaction": transaction.to_xdr(),
             "resourceConfig": None,
             "authMode": None,
-            "authV2": False,
         }
 
     def test_simulate_transaction_with_addl_resources(self):
@@ -929,7 +928,6 @@ class TestSorobanServer:
             "transaction": transaction.to_xdr(),
             "resourceConfig": {"instructionLeeway": 1000000},
             "authMode": None,
-            "authV2": False,
         }
 
     def test_simulate_transaction_with_auth_mode(self):
@@ -978,57 +976,6 @@ class TestSorobanServer:
             "transaction": transaction.to_xdr(),
             "resourceConfig": None,
             "authMode": "record_allow_nonroot",
-            "authV2": False,
-        }
-
-    def test_simulate_transaction_with_auth_v2(self):
-        result = {"latestLedger": 1479}
-        data = {
-            "jsonrpc": "2.0",
-            "id": "e1fabdcdf0244a2a9adfab94d7748b6c",
-            "result": result,
-        }
-        transaction = _build_soroban_transaction(None, [])
-        with requests_mock.Mocker() as m:
-            m.post(RPC_URL, json=data)
-            assert SorobanServer(RPC_URL).simulate_transaction(
-                transaction, auth_v2=True
-            ) == SimulateTransactionResponse.model_validate(result)
-
-        request_data = m.last_request.json()
-        assert len(request_data["id"]) == 32
-        assert request_data["jsonrpc"] == "2.0"
-        assert request_data["method"] == "simulateTransaction"
-        assert request_data["params"] == {
-            "transaction": transaction.to_xdr(),
-            "resourceConfig": None,
-            "authMode": None,
-            "authV2": True,
-        }
-
-    def test_simulate_transaction_with_auth_v2_false(self):
-        result = {"latestLedger": 1479}
-        data = {
-            "jsonrpc": "2.0",
-            "id": "e1fabdcdf0244a2a9adfab94d7748b6c",
-            "result": result,
-        }
-        transaction = _build_soroban_transaction(None, [])
-        with requests_mock.Mocker() as m:
-            m.post(RPC_URL, json=data)
-            assert SorobanServer(RPC_URL).simulate_transaction(
-                transaction, auth_v2=False
-            ) == SimulateTransactionResponse.model_validate(result)
-
-        request_data = m.last_request.json()
-        assert len(request_data["id"]) == 32
-        assert request_data["jsonrpc"] == "2.0"
-        assert request_data["method"] == "simulateTransaction"
-        assert request_data["params"] == {
-            "transaction": transaction.to_xdr(),
-            "resourceConfig": None,
-            "authMode": None,
-            "authV2": False,
         }
 
     def test_prepare_transaction_without_auth_and_soroban_data(self):


### PR DESCRIPTION
Reverts the `authV2` opt-in flag for `simulateTransaction` added in #1188 (commit e96f579).

The RPC-side changes that this flag depends on are **not confirmed yet**, so we're holding off on the `authV2: true` opt-in and the associated RPC behavior (silently ignoring unrecognized fields / returning legacy `ADDRESS` entries) until they actually land upstream.

The rest of the CAP-71 / Protocol 27 work (XDR changes, the new `HashIDPreimage` arm, preimage selection by credential type, delegated auth handling, and the xdrgen preprocessing steps) is unaffected and stays in place.

This is a clean `git revert` of e96f5791762aecb498c416b51fda3d52ac98e83d. It can be re-applied once the RPC changes are confirmed.