### PR TITLE
fix: Get SAC balance

### DIFF
--- a/stellar_sdk/base_soroban_server.py
+++ b/stellar_sdk/base_soroban_server.py
@@ -6,8 +6,10 @@ import uuid
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from . import scval
 from . import xdr as stellar_xdr
 from .address import Address
+from .asset import Asset
 from .operation import InvokeHostFunction
 from .soroban_rpc import *
 
@@ -39,6 +41,30 @@ def _build_contract_instance_key(contract_id: str) -> stellar_xdr.LedgerKey:
             key=stellar_xdr.SCVal(
                 stellar_xdr.SCValType.SCV_LEDGER_KEY_CONTRACT_INSTANCE
             ),
+            durability=stellar_xdr.ContractDataDurability.PERSISTENT,
+        ),
+    )
+
+
+def _build_sac_balance_ledger_key(
+    asset: Asset,
+    contract_id: str,
+    network_passphrase: str,
+) -> stellar_xdr.LedgerKey:
+    """Build the ledger key for an SAC asset balance held by a contract.
+
+    :param asset: The SAC asset whose balance ledger entry should be looked up.
+    :param contract_id: The contract ID that holds the asset balance.
+    :param network_passphrase: The network passphrase used to derive the SAC contract ID.
+    :return: The persistent contract-data ledger key for the balance entry.
+    """
+    sac_id = asset.contract_id(network_passphrase)
+    key = scval.to_vec([scval.to_symbol("Balance"), scval.to_address(contract_id)])
+    return stellar_xdr.LedgerKey(
+        stellar_xdr.LedgerEntryType.CONTRACT_DATA,
+        contract_data=stellar_xdr.LedgerKeyContractData(
+            contract=Address(sac_id).to_xdr_sc_address(),
+            key=key,
             durability=stellar_xdr.ContractDataDurability.PERSISTENT,
         ),
     )

--- a/stellar_sdk/soroban_rpc.py
+++ b/stellar_sdk/soroban_rpc.py
@@ -6,6 +6,9 @@ from typing import Any, Generic, TypeVar
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing_extensions import Self
 
+from . import scval
+from . import xdr as stellar_xdr
+
 T = TypeVar("T")
 
 Id = str | int
@@ -532,6 +535,31 @@ class GetSACBalanceResponse(BaseModel):
     balance_entry: SACBalanceEntry | None = Field(
         description="The balance entry for the account. If there is not a valid balance entry, this will be None."
     )
+
+    @classmethod
+    def from_ledger_entry_result(
+        cls,
+        ledger_entry_result: LedgerEntryResult,
+        latest_ledger: int,
+    ) -> Self:
+        entry_data = stellar_xdr.LedgerEntryData.from_xdr(ledger_entry_result.xdr)
+
+        if entry_data.type != stellar_xdr.LedgerEntryType.CONTRACT_DATA:
+            return cls(latest_ledger=latest_ledger, balance_entry=None)
+
+        assert entry_data.contract_data is not None
+        contract_data = scval.to_native(entry_data.contract_data.val)
+        assert isinstance(contract_data, dict)
+        return cls(
+            latest_ledger=latest_ledger,
+            balance_entry=SACBalanceEntry(
+                amount=contract_data["amount"],
+                authorized=contract_data["authorized"],
+                clawback=contract_data["clawback"],
+                last_modified_ledger=ledger_entry_result.last_modified_ledger,
+                live_until_ledger=ledger_entry_result.live_until_ledger,
+            ),
+        )
 
 
 DEFAULT_POLLING_ATTEMPTS: int = 30

--- a/stellar_sdk/soroban_server.py
+++ b/stellar_sdk/soroban_server.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
-from . import scval
 from . import xdr as stellar_xdr
 from .account import Account
 from .address import Address
@@ -37,13 +36,6 @@ from .sep.contract_meta import ContractMeta
 from .sep.contract_spec import ContractSpec
 from .soroban_rpc import *
 from .strkey import StrKey
-from .xdr import (
-    ContractDataDurability,
-    LedgerEntryData,
-    LedgerEntryType,
-    LedgerKey,
-    LedgerKeyContractData,
-)
 
 if TYPE_CHECKING:
     from .client.base_sync_client import BaseSyncClient

--- a/stellar_sdk/soroban_server.py
+++ b/stellar_sdk/soroban_server.py
@@ -16,6 +16,7 @@ from .base_soroban_server import (
     ResourceLeeway,
     _assemble_transaction,
     _build_contract_instance_key,
+    _build_sac_balance_ledger_key,
     _generate_unique_request_id,
     _validate_wasm_hash,
 )
@@ -548,42 +549,14 @@ class SorobanServer:
         if network_passphrase is None:
             network_passphrase = self.get_network().passphrase
 
-        sac_id = sac.contract_id(network_passphrase)
-        key = scval.to_vec([scval.to_symbol("Balance"), scval.to_address(sac_id)])
-        ledger_key = LedgerKey(
-            LedgerEntryType.CONTRACT_DATA,
-            contract_data=LedgerKeyContractData(
-                contract=Address(sac_id).to_xdr_sc_address(),
-                key=key,
-                durability=ContractDataDurability.PERSISTENT,
-            ),
-        )
+        ledger_key = _build_sac_balance_ledger_key(sac, contract_id, network_passphrase)
         response = self.get_ledger_entries([ledger_key])
-        if not response.entries:
+        if not response.entries or len(response.entries) != 1:
             return GetSACBalanceResponse(
                 latest_ledger=response.latest_ledger, balance_entry=None
             )
-
-        raw_entry = response.entries[0]
-        entry_data = LedgerEntryData.from_xdr(raw_entry.xdr)
-
-        if entry_data.type != LedgerEntryType.CONTRACT_DATA:
-            return GetSACBalanceResponse(
-                latest_ledger=response.latest_ledger, balance_entry=None
-            )
-
-        assert entry_data.contract_data is not None
-        contract_data = scval.to_native(entry_data.contract_data.val)
-        assert isinstance(contract_data, dict)
-        return GetSACBalanceResponse(
-            latest_ledger=response.latest_ledger,
-            balance_entry=SACBalanceEntry(
-                amount=contract_data["amount"],
-                authorized=contract_data["authorized"],
-                clawback=contract_data["clawback"],
-                last_modified_ledger=raw_entry.last_modified_ledger,
-                live_until_ledger=raw_entry.live_until_ledger,
-            ),
+        return GetSACBalanceResponse.from_ledger_entry_result(
+            response.entries[0], response.latest_ledger
         )
 
     def prepare_transaction(

--- a/stellar_sdk/soroban_server_async.py
+++ b/stellar_sdk/soroban_server_async.py
@@ -16,6 +16,7 @@ from .base_soroban_server import (
     ResourceLeeway,
     _assemble_transaction,
     _build_contract_instance_key,
+    _build_sac_balance_ledger_key,
     _generate_unique_request_id,
     _validate_wasm_hash,
 )
@@ -547,42 +548,14 @@ class SorobanServerAsync:
         if network_passphrase is None:
             network_passphrase = (await self.get_network()).passphrase
 
-        sac_id = sac.contract_id(network_passphrase)
-        key = scval.to_vec([scval.to_symbol("Balance"), scval.to_address(sac_id)])
-        ledger_key = LedgerKey(
-            LedgerEntryType.CONTRACT_DATA,
-            contract_data=LedgerKeyContractData(
-                contract=Address(sac_id).to_xdr_sc_address(),
-                key=key,
-                durability=ContractDataDurability.PERSISTENT,
-            ),
-        )
+        ledger_key = _build_sac_balance_ledger_key(sac, contract_id, network_passphrase)
         response = await self.get_ledger_entries([ledger_key])
-        if not response.entries:
+        if not response.entries or len(response.entries) != 1:
             return GetSACBalanceResponse(
                 latest_ledger=response.latest_ledger, balance_entry=None
             )
-
-        raw_entry = response.entries[0]
-        entry_data = LedgerEntryData.from_xdr(raw_entry.xdr)
-
-        if entry_data.type != LedgerEntryType.CONTRACT_DATA:
-            return GetSACBalanceResponse(
-                latest_ledger=response.latest_ledger, balance_entry=None
-            )
-
-        assert entry_data.contract_data is not None
-        contract_data = scval.to_native(entry_data.contract_data.val)
-        assert isinstance(contract_data, dict)
-        return GetSACBalanceResponse(
-            latest_ledger=response.latest_ledger,
-            balance_entry=SACBalanceEntry(
-                amount=contract_data["amount"],
-                authorized=contract_data["authorized"],
-                clawback=contract_data["clawback"],
-                last_modified_ledger=raw_entry.last_modified_ledger,
-                live_until_ledger=raw_entry.live_until_ledger,
-            ),
+        return GetSACBalanceResponse.from_ledger_entry_result(
+            response.entries[0], response.latest_ledger
         )
 
     async def prepare_transaction(

--- a/stellar_sdk/soroban_server_async.py
+++ b/stellar_sdk/soroban_server_async.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
-from . import scval
 from . import xdr as stellar_xdr
 from .account import Account
 from .address import Address
@@ -37,13 +36,6 @@ from .sep.contract_meta import ContractMeta
 from .sep.contract_spec import ContractSpec
 from .soroban_rpc import *
 from .strkey import StrKey
-from .xdr import (
-    ContractDataDurability,
-    LedgerEntryData,
-    LedgerEntryType,
-    LedgerKey,
-    LedgerKeyContractData,
-)
 
 if TYPE_CHECKING:
     from .client.base_async_client import BaseAsyncClient

--- a/tests/test_get_sac_balance_response.py
+++ b/tests/test_get_sac_balance_response.py
@@ -1,0 +1,53 @@
+from stellar_sdk.soroban_rpc import (
+    GetSACBalanceResponse,
+    LedgerEntryResult,
+    SACBalanceEntry,
+)
+
+
+def test_from_ledger_entry_result_returns_none_for_non_contract_data():
+    ledger_entry_result = LedgerEntryResult.model_validate(
+        {
+            "key": "AAAAAAAAAACynni6I2ACEzWuORVM1b2y0k1ZDni0W6JlC/Ad/mfCSg==",
+            "xdr": "AAAAAAAAAACynni6I2ACEzWuORVM1b2y0k1ZDni0W6JlC/Ad/mfCSgAAABdIdugAAAAAnwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA",
+            "lastModifiedLedgerSeq": 159,
+            "liveUntilLedgerSeq": 288,
+        }
+    )
+
+    response = GetSACBalanceResponse.from_ledger_entry_result(
+        ledger_entry_result, latest_ledger=7943
+    )
+
+    assert response == GetSACBalanceResponse(
+        latest_ledger=7943, balance_entry=None
+    )
+
+
+def test_from_ledger_entry_result_returns_balance_entry_for_contract_data():
+    latest_ledger = 57387047
+    last_modified_ledger = 57386587
+    live_until_ledger = 57904987
+    ledger_entry_result = LedgerEntryResult.model_validate(
+        {
+            "key": "AAAABgAAAAAAAAABJbT82FmuwvpjSEOMSJs8PBDJi20hvk/TyzDLaJU++XcAAAAQAAAAAQAAAAIAAAAPAAAAB0JhbGFuY2UAAAAAEgAAAAEltPzYWa7C+mNIQ4xImzw8EMmLbSG+T9PLMMtolT75dwAAAAEAAAARAAAAAQAAAAMAAAAPAAAABmFtb3VudAAAAAAACgAAAAAAAAAAAAAAABFKkyUAAAAPAAAACmF1dGhvcml6ZWQAAAAAAAAAAAABAAAADwAAAAhjbGF3YmFjawAAAAAAAAAA",
+            "xdr": "AAAABgAAAAAAAAABJbT82FmuwvpjSEOMSJs8PBDJi20hvk/TyzDLaJU++XcAAAAQAAAAAQAAAAIAAAAPAAAAB0JhbGFuY2UAAAAAEgAAAAEltPzYWa7C+mNIQ4xImzw8EMmLbSG+T9PLMMtolT75dwAAAAEAAAARAAAAAQAAAAMAAAAPAAAABmFtb3VudAAAAAAACgAAAAAAAAAAAAAAABFKkyUAAAAPAAAACmF1dGhvcml6ZWQAAAAAAAAAAAABAAAADwAAAAhjbGF3YmFjawAAAAAAAAAA",
+            "lastModifiedLedgerSeq": last_modified_ledger,
+            "liveUntilLedgerSeq": live_until_ledger,
+        }
+    )
+
+    response = GetSACBalanceResponse.from_ledger_entry_result(
+        ledger_entry_result, latest_ledger=latest_ledger
+    )
+
+    assert response == GetSACBalanceResponse(
+        latest_ledger=latest_ledger,
+        balance_entry=SACBalanceEntry(
+            amount=290100005,
+            authorized=True,
+            clawback=False,
+            last_modified_ledger=last_modified_ledger,
+            live_until_ledger=live_until_ledger,
+        ),
+    )

--- a/tests/test_get_sac_balance_response.py
+++ b/tests/test_get_sac_balance_response.py
@@ -19,9 +19,7 @@ def test_from_ledger_entry_result_returns_none_for_non_contract_data():
         ledger_entry_result, latest_ledger=7943
     )
 
-    assert response == GetSACBalanceResponse(
-        latest_ledger=7943, balance_entry=None
-    )
+    assert response == GetSACBalanceResponse(latest_ledger=7943, balance_entry=None)
 
 
 def test_from_ledger_entry_result_returns_balance_entry_for_contract_data():

--- a/tests/test_soroban_server_async.py
+++ b/tests/test_soroban_server_async.py
@@ -752,16 +752,33 @@ class TestSorobanServer:
         }
 
     async def test_get_sac_balance(self):
+        contract_id = "CC25B67T7RG7IBWVQKBFRC6SR4MJDHYFDGMIQYVVI7WE55TPUILMH5YT"
+        sac = Asset.native()
+        network_passphrase = Network.PUBLIC_NETWORK_PASSPHRASE
+        sac_id = sac.contract_id(network_passphrase)
+        key = scval.to_vec([scval.to_symbol("Balance"), scval.to_address(contract_id)])
+        ledger_key = stellar_xdr.LedgerKey(
+            stellar_xdr.LedgerEntryType.CONTRACT_DATA,
+            contract_data=stellar_xdr.LedgerKeyContractData(
+                contract=Address(sac_id).to_xdr_sc_address(),
+                key=key,
+                durability=stellar_xdr.ContractDataDurability.PERSISTENT,
+            ),
+        )
+        expected_key = ledger_key.to_xdr()
+        latest_ledger = 57387047
+        last_modified_ledger = 57386587
+        live_until_ledger = 57904987
         result = {
             "entries": [
                 {
-                    "key": "AAAABgAAAAEltPzYWa7C+mNIQ4xImzw8EMmLbSG+T9PLMMtolT75dwAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAASW0/NhZrsL6Y0hDjEibPDwQyYttIb5P08swy2iVPvl3AAAAAQ==",
+                    "key": expected_key,
                     "xdr": "AAAABgAAAAAAAAABJbT82FmuwvpjSEOMSJs8PBDJi20hvk/TyzDLaJU++XcAAAAQAAAAAQAAAAIAAAAPAAAAB0JhbGFuY2UAAAAAEgAAAAEltPzYWa7C+mNIQ4xImzw8EMmLbSG+T9PLMMtolT75dwAAAAEAAAARAAAAAQAAAAMAAAAPAAAABmFtb3VudAAAAAAACgAAAAAAAAAAAAAAABFKkyUAAAAPAAAACmF1dGhvcml6ZWQAAAAAAAAAAAABAAAADwAAAAhjbGF3YmFjawAAAAAAAAAA",
-                    "lastModifiedLedgerSeq": 57386587,
-                    "liveUntilLedgerSeq": 57904987,
+                    "lastModifiedLedgerSeq": last_modified_ledger,
+                    "liveUntilLedgerSeq": live_until_ledger,
                 }
             ],
-            "latestLedger": 57387047,
+            "latestLedger": latest_ledger,
         }
         data = {
             "jsonrpc": "2.0",
@@ -769,49 +786,70 @@ class TestSorobanServer:
             "result": result,
         }
         expected_result = GetSACBalanceResponse(
-            latest_ledger=57387047,
+            latest_ledger=latest_ledger,
             balance_entry=SACBalanceEntry(
                 amount=290100005,
                 authorized=True,
                 clawback=False,
-                last_modified_ledger=57386587,
-                live_until_ledger=57904987,
+                last_modified_ledger=last_modified_ledger,
+                live_until_ledger=live_until_ledger,
             ),
         )
         with aioresponses() as m:
             m.post(RPC_URL, payload=data)
             assert (
                 await SorobanServerAsync(RPC_URL).get_sac_balance(
-                    "CC25B67T7RG7IBWVQKBFRC6SR4MJDHYFDGMIQYVVI7WE55TPUILMH5YT",
-                    Asset.native(),
-                    Network.PUBLIC_NETWORK_PASSPHRASE,
+                    contract_id,
+                    sac,
+                    network_passphrase,
                 )
                 == expected_result
             )
 
+        request_data = m.requests[("POST", URL(RPC_URL))][0].kwargs["json"]
+        assert request_data["params"]["keys"] == [expected_key]
+
     async def test_get_sac_balance_with_empty_balance_entry(self):
-        result = {"entries": [], "latestLedger": 57387178}
+        contract_id = "CDOAW6D7NXAPOCO7TFAWZNJHK62E3IYRGNRVX3VOXNKNVOXCLLPJXQCF"
+        sac = Asset(
+            "yXLM",
+            "GARDNV3Q7YGT4AKSDF25LT32YSCCW4EV22Y2TV3I2PU2MMXJTEDL5T55",
+        )
+        network_passphrase = Network.PUBLIC_NETWORK_PASSPHRASE
+        sac_id = sac.contract_id(network_passphrase)
+        key = scval.to_vec([scval.to_symbol("Balance"), scval.to_address(contract_id)])
+        ledger_key = stellar_xdr.LedgerKey(
+            stellar_xdr.LedgerEntryType.CONTRACT_DATA,
+            contract_data=stellar_xdr.LedgerKeyContractData(
+                contract=Address(sac_id).to_xdr_sc_address(),
+                key=key,
+                durability=stellar_xdr.ContractDataDurability.PERSISTENT,
+            ),
+        )
+        expected_key = ledger_key.to_xdr()
+        latest_ledger = 57387178
+        result = {"entries": [], "latestLedger": latest_ledger}
         data = {
             "jsonrpc": "2.0",
             "id": "e1fabdcdf0244a2a9adfab94d7748b6c",
             "result": result,
         }
         expected_result = GetSACBalanceResponse(
-            latest_ledger=57387178, balance_entry=None
+            latest_ledger=latest_ledger, balance_entry=None
         )
         with aioresponses() as m:
             m.post(RPC_URL, payload=data)
             assert (
                 await SorobanServerAsync(RPC_URL).get_sac_balance(
-                    "CDOAW6D7NXAPOCO7TFAWZNJHK62E3IYRGNRVX3VOXNKNVOXCLLPJXQCF",
-                    Asset(
-                        "yXLM",
-                        "GARDNV3Q7YGT4AKSDF25LT32YSCCW4EV22Y2TV3I2PU2MMXJTEDL5T55",
-                    ),
-                    Network.PUBLIC_NETWORK_PASSPHRASE,
+                    contract_id,
+                    sac,
+                    network_passphrase,
                 )
                 == expected_result
             )
+
+        request_data = m.requests[("POST", URL(RPC_URL))][0].kwargs["json"]
+        assert request_data["params"]["keys"] == [expected_key]
 
     async def test_simulate_transaction(self):
         result = {

--- a/tests/test_soroban_server_sync.py
+++ b/tests/test_soroban_server_sync.py
@@ -781,16 +781,33 @@ class TestSorobanServer:
             assert isinstance(SorobanServer(RPC_URL).get_ledgers(), GetLedgersResponse)
 
     def test_get_sac_balance(self):
+        contract_id = "CC25B67T7RG7IBWVQKBFRC6SR4MJDHYFDGMIQYVVI7WE55TPUILMH5YT"
+        sac = Asset.native()
+        network_passphrase = Network.PUBLIC_NETWORK_PASSPHRASE
+        sac_id = sac.contract_id(network_passphrase)
+        key = scval.to_vec([scval.to_symbol("Balance"), scval.to_address(contract_id)])
+        ledger_key = stellar_xdr.LedgerKey(
+            stellar_xdr.LedgerEntryType.CONTRACT_DATA,
+            contract_data=stellar_xdr.LedgerKeyContractData(
+                contract=Address(sac_id).to_xdr_sc_address(),
+                key=key,
+                durability=stellar_xdr.ContractDataDurability.PERSISTENT,
+            ),
+        )
+        expected_key = ledger_key.to_xdr()
+        latest_ledger = 57387047
+        last_modified_ledger = 57386587
+        live_until_ledger = 57904987
         result = {
             "entries": [
                 {
-                    "key": "AAAABgAAAAEltPzYWa7C+mNIQ4xImzw8EMmLbSG+T9PLMMtolT75dwAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAASW0/NhZrsL6Y0hDjEibPDwQyYttIb5P08swy2iVPvl3AAAAAQ==",
+                    "key": expected_key,
                     "xdr": "AAAABgAAAAAAAAABJbT82FmuwvpjSEOMSJs8PBDJi20hvk/TyzDLaJU++XcAAAAQAAAAAQAAAAIAAAAPAAAAB0JhbGFuY2UAAAAAEgAAAAEltPzYWa7C+mNIQ4xImzw8EMmLbSG+T9PLMMtolT75dwAAAAEAAAARAAAAAQAAAAMAAAAPAAAABmFtb3VudAAAAAAACgAAAAAAAAAAAAAAABFKkyUAAAAPAAAACmF1dGhvcml6ZWQAAAAAAAAAAAABAAAADwAAAAhjbGF3YmFjawAAAAAAAAAA",
-                    "lastModifiedLedgerSeq": 57386587,
-                    "liveUntilLedgerSeq": 57904987,
+                    "lastModifiedLedgerSeq": last_modified_ledger,
+                    "liveUntilLedgerSeq": live_until_ledger,
                 }
             ],
-            "latestLedger": 57387047,
+            "latestLedger": latest_ledger,
         }
         data = {
             "jsonrpc": "2.0",
@@ -798,49 +815,70 @@ class TestSorobanServer:
             "result": result,
         }
         expected_result = GetSACBalanceResponse(
-            latest_ledger=57387047,
+            latest_ledger=latest_ledger,
             balance_entry=SACBalanceEntry(
                 amount=290100005,
                 authorized=True,
                 clawback=False,
-                last_modified_ledger=57386587,
-                live_until_ledger=57904987,
+                last_modified_ledger=last_modified_ledger,
+                live_until_ledger=live_until_ledger,
             ),
         )
         with requests_mock.Mocker() as m:
             m.post(RPC_URL, json=data)
             assert (
                 SorobanServer(RPC_URL).get_sac_balance(
-                    "CC25B67T7RG7IBWVQKBFRC6SR4MJDHYFDGMIQYVVI7WE55TPUILMH5YT",
-                    Asset.native(),
-                    Network.PUBLIC_NETWORK_PASSPHRASE,
+                    contract_id,
+                    sac,
+                    network_passphrase,
                 )
                 == expected_result
             )
 
+        request_data = m.last_request.json()
+        assert request_data["params"]["keys"] == [expected_key]
+
     def test_get_sac_balance_with_empty_balance_entry(self):
-        result = {"entries": [], "latestLedger": 57387178}
+        contract_id = "CDOAW6D7NXAPOCO7TFAWZNJHK62E3IYRGNRVX3VOXNKNVOXCLLPJXQCF"
+        sac = Asset(
+            "yXLM",
+            "GARDNV3Q7YGT4AKSDF25LT32YSCCW4EV22Y2TV3I2PU2MMXJTEDL5T55",
+        )
+        network_passphrase = Network.PUBLIC_NETWORK_PASSPHRASE
+        sac_id = sac.contract_id(network_passphrase)
+        key = scval.to_vec([scval.to_symbol("Balance"), scval.to_address(contract_id)])
+        ledger_key = stellar_xdr.LedgerKey(
+            stellar_xdr.LedgerEntryType.CONTRACT_DATA,
+            contract_data=stellar_xdr.LedgerKeyContractData(
+                contract=Address(sac_id).to_xdr_sc_address(),
+                key=key,
+                durability=stellar_xdr.ContractDataDurability.PERSISTENT,
+            ),
+        )
+        expected_key = ledger_key.to_xdr()
+        latest_ledger = 57387178
+        result = {"entries": [], "latestLedger": latest_ledger}
         data = {
             "jsonrpc": "2.0",
             "id": "e1fabdcdf0244a2a9adfab94d7748b6c",
             "result": result,
         }
         expected_result = GetSACBalanceResponse(
-            latest_ledger=57387178, balance_entry=None
+            latest_ledger=latest_ledger, balance_entry=None
         )
         with requests_mock.Mocker() as m:
             m.post(RPC_URL, json=data)
             assert (
                 SorobanServer(RPC_URL).get_sac_balance(
-                    "CDOAW6D7NXAPOCO7TFAWZNJHK62E3IYRGNRVX3VOXNKNVOXCLLPJXQCF",
-                    Asset(
-                        "yXLM",
-                        "GARDNV3Q7YGT4AKSDF25LT32YSCCW4EV22Y2TV3I2PU2MMXJTEDL5T55",
-                    ),
-                    Network.PUBLIC_NETWORK_PASSPHRASE,
+                    contract_id,
+                    sac,
+                    network_passphrase,
                 )
                 == expected_result
             )
+
+        request_data = m.last_request.json()
+        assert request_data["params"]["keys"] == [expected_key]
 
     def test_simulate_transaction(self):
         result = {


### PR DESCRIPTION
Fixes #1195: Get the SAC balance held by the *requested contract* instead of the SAC balance held by the SAC itself.
In addition, dedup some of the business logic.